### PR TITLE
Odoo module installation failure due to missing menu item

### DIFF
--- a/odoo17/addons/facilities_management/views/facility_views.xml
+++ b/odoo17/addons/facilities_management/views/facility_views.xml
@@ -338,10 +338,4 @@
         </field>
     </record>
 
-    <!-- Facility Menu -->
-    <menuitem id="menu_facility"
-              name="Facilities"
-              parent="menu_facility_records"
-              action="action_facility"
-              sequence="10"/>
 </odoo>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove duplicate 'Facilities' menu item to resolve "External ID not found" error during module installation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `menu_facility` item in `facility_views.xml` caused a `ParseError` because its parent, `menu_facility_records`, was defined in `facility_asset_menus.xml`, which was loaded later in the manifest. This created a loading order dependency issue. Furthermore, this menu was a duplicate of `menu_facility_list_item` already correctly defined in `facility_asset_menus.xml`. Removing the redundant definition resolves the loading order conflict and the external ID error.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc7e2873-a01b-457a-8e89-92bc6ce6b73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc7e2873-a01b-457a-8e89-92bc6ce6b73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>