### PR TITLE
Install facilities management module with missing view reference

### DIFF
--- a/odoo17/addons/facilities_management/__manifest__.py
+++ b/odoo17/addons/facilities_management/__manifest__.py
@@ -57,13 +57,13 @@ Features:
 
         # Views - Core Facilities
         'views/facility_views.xml',
-        'views/facility_asset_menus.xml',
         'views/floor_views.xml',
         'views/room_views.xml',
         'views/building_views.xml',
 
         # Views - Assets
         'views/asset_calendar_views.xml',
+        'views/facility_asset_menus.xml',
         'views/facility_asset_views.xml',
         'views/asset_category_views.xml',
         'views/asset_dashboard_views.xml',


### PR DESCRIPTION
Reordered XML file loading in `__manifest__.py` to resolve a `ParseError`.

The `facility_asset_menus.xml` file was attempting to reference `view_facilities_asset_calendar_warranty` before its definition in `asset_calendar_views.xml` was loaded, causing a `ValueError: External ID not found`. This commit ensures `asset_calendar_views.xml` is loaded prior to `facility_asset_menus.xml`, resolving the dependency issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0ad5e0b-106f-471b-8f61-e94a1b2a046a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0ad5e0b-106f-471b-8f61-e94a1b2a046a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>