### PR TITLE
Fix facilities management module loading error

### DIFF
--- a/odoo17/addons/facilities_management/models/building.py
+++ b/odoo17/addons/facilities_management/models/building.py
@@ -55,3 +55,15 @@ class FacilityBuilding(models.Model):
         for rec in self:
             if not rec.facility_id:
                 raise fields.ValidationError("A building must be linked to a Facility.")
+
+    def action_view_floors(self):
+        """Open the floors view for this building."""
+        self.ensure_one()
+        return {
+            'name': 'Floors',
+            'type': 'ir.actions.act_window',
+            'res_model': 'facilities.floor',
+            'view_mode': 'tree,form',
+            'domain': [('building_id', '=', self.id)],
+            'context': {'default_building_id': self.id},
+        }

--- a/odoo17/addons/facilities_management/models/floor.py
+++ b/odoo17/addons/facilities_management/models/floor.py
@@ -45,3 +45,15 @@ class FacilityFloor(models.Model):
         for rec in self:
             if not rec.building_id:
                 raise fields.ValidationError("A floor must be linked to a Building.")
+
+    def action_view_rooms(self):
+        """Open the rooms view for this floor."""
+        self.ensure_one()
+        return {
+            'name': 'Rooms',
+            'type': 'ir.actions.act_window',
+            'res_model': 'facilities.room',
+            'view_mode': 'kanban,tree,form',
+            'domain': [('floor_id', '=', self.id)],
+            'context': {'default_floor_id': self.id},
+        }

--- a/odoo17/addons/facilities_management/views/building_views.xml
+++ b/odoo17/addons/facilities_management/views/building_views.xml
@@ -23,7 +23,7 @@
             <form string="Building">
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" name="%(action_facilities_floor)d" type="action" icon="fa-th-large">
+                        <button class="oe_stat_button" name="action_view_floors" type="object" icon="fa-th-large">
                             <field name="floor_count" widget="statinfo" string="Floors"/>
                         </button>
                         </div>

--- a/odoo17/addons/facilities_management/views/floor_views.xml
+++ b/odoo17/addons/facilities_management/views/floor_views.xml
@@ -23,7 +23,7 @@
             <form string="Floor">
                 <sheet>
                     <div class="oe_button_box" name="button_box">
-                        <button class="oe_stat_button" name="%(action_facilities_room)d" type="action" icon="fa-cube">
+                        <button class="oe_stat_button" name="action_view_rooms" type="object" icon="fa-cube">
                             <field name="room_count" widget="statinfo" string="Rooms"/>
                         </button>
                     </div>


### PR DESCRIPTION
Replace XML action references with Python method calls for buttons in building and floor views to resolve "External ID not found" errors.

The original issue was a `ValueError: External ID not found` during module installation, caused by a loading order dependency where XML actions were not yet registered when views tried to reference them. By changing button `type` to `object` and calling a Python method, the dependency on the XML action's external ID is removed, ensuring robust module installation while maintaining the same functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5db83d4-f937-4d32-8660-3043c993def6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5db83d4-f937-4d32-8660-3043c993def6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>