### PR TITLE
Install facilities management module

### DIFF
--- a/odoo17/addons/facilities_management/views/asset_sensor_views.xml
+++ b/odoo17/addons/facilities_management/views/asset_sensor_views.xml
@@ -415,23 +415,4 @@
             </p>
         </field>
     </record>
-
-    <!-- Menu Items -->
-    <menuitem id="menu_asset_sensor"
-              name="Asset Sensors"
-              parent="menu_asset_monitoring"
-              action="action_asset_sensor"
-              sequence="50"/>
-
-    <menuitem id="menu_asset_threshold"
-              name="Asset Thresholds"
-              parent="menu_asset_monitoring"
-              action="action_asset_threshold"
-              sequence="51"/>
-
-    <menuitem id="menu_asset_sensor_data"
-              name="Sensor Data"
-              parent="menu_asset_monitoring"
-              action="action_asset_sensor_data"
-              sequence="52"/>
 </odoo>

--- a/odoo17/addons/facilities_management/views/facility_asset_menus.xml
+++ b/odoo17/addons/facilities_management/views/facility_asset_menus.xml
@@ -430,6 +430,24 @@
               action="action_predictive_maintenance"
               sequence="30"/>
 
+    <menuitem id="menu_asset_sensor"
+              name="Asset Sensors"
+              parent="menu_asset_monitoring"
+              action="action_asset_sensor"
+              sequence="40"/>
+
+    <menuitem id="menu_asset_threshold"
+              name="Asset Thresholds"
+              parent="menu_asset_monitoring"
+              action="action_asset_threshold"
+              sequence="41"/>
+
+    <menuitem id="menu_asset_sensor_data"
+              name="Sensor Data"
+              parent="menu_asset_monitoring"
+              action="action_asset_sensor_data"
+              sequence="42"/>
+
     <!-- MAINTENANCE SECTION -->
     <menuitem id="menu_maintenance"
               name="Maintenance"


### PR DESCRIPTION
Move asset sensor menu items to the correct menu definition file to fix module installation errors.

The `facilities_management` module failed to install with a `ValueError: External ID not found in the system: facilities_management.menu_asset_monitoring`. This was due to `asset_sensor_views.xml` attempting to set `menu_asset_monitoring` as a parent before `facility_asset_menus.xml` (where `menu_asset_monitoring` is defined) was loaded. Moving these menu items ensures proper loading order and resolves the dependency issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-915131b2-c1cf-4d43-bbdc-372471671828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-915131b2-c1cf-4d43-bbdc-372471671828">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>