### PR TITLE
Fix missing menu item parent id

### DIFF
--- a/odoo17/addons/facilities_management/views/asset_disposal_wizard_views.xml
+++ b/odoo17/addons/facilities_management/views/asset_disposal_wizard_views.xml
@@ -216,7 +216,7 @@
         <!-- Asset Disposal Menu -->
         <menuitem id="menu_asset_disposal"
                   name="Asset Disposals"
-                  parent="facilities_management.menu_asset_operations"
+                  parent="menu_asset_operations"
                   action="action_asset_disposal"
                   sequence="50"/>
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove module prefix from `menu_asset_operations` parent reference to fix 'External ID not found' error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---
<a href="https://cursor.com/background-agent?bcId=bc-6dc75158-59d1-4f59-b269-06bc0d2d18e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dc75158-59d1-4f59-b269-06bc0d2d18e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>