### PR TITLE
Fix maintenance workorder view parsing error

### DIFF
--- a/odoo17/addons/facilities_management/models/maintenance_workorder.py
+++ b/odoo17/addons/facilities_management/models/maintenance_workorder.py
@@ -563,6 +563,16 @@ class MaintenanceWorkOrder(models.Model):
         })
         self.message_post(body=_("Work order completed by %s") % self.env.user.name)
 
+    def action_cancel(self):
+        self.ensure_one()
+        if self.state in ('done', 'cancelled'):
+            raise UserError(_("Cannot cancel a work order that is already done or cancelled."))
+        self.write({
+            'approval_state': 'cancelled',
+            'state': 'cancelled'
+        })
+        self.message_post(body=_("Work order cancelled by %s") % self.env.user.name)
+
     @api.depends('section_ids.task_ids.is_done', 'workorder_task_ids.is_done')
     def _compute_all_tasks_completed(self):
         for workorder in self:


### PR DESCRIPTION
Add `action_cancel` method to `maintenance.workorder` model to resolve a view validation error.

The `maintenance_workorder_views.xml` contained a button that called `action_cancel`, but this method was not defined in the `maintenance.workorder` model, leading to a `ParseError` during module installation. This PR adds the missing method to allow proper cancellation of work orders and resolve the installation issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2d38073-3310-4af6-94b9-f413e13a2669">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2d38073-3310-4af6-94b9-f413e13a2669">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>