### PR TITLE
Fix missing menu item external id in facilities management

### DIFF
--- a/fix_action_maintenance_workorder.xml
+++ b/fix_action_maintenance_workorder.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <!-- Create the missing action_maintenance_workorder -->
+        <record id="action_maintenance_workorder" model="ir.actions.act_window">
+            <field name="name">Maintenance Work Orders</field>
+            <field name="res_model">maintenance.workorder</field>
+            <field name="view_mode">tree,form,calendar,kanban</field>
+            <field name="domain">[]</field>
+            <field name="context">{}</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Create your first maintenance work order!
+                </p>
+                <p>
+                    Track and manage maintenance work orders for your facilities and assets.
+                </p>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add missing `action_maintenance_workorder` to resolve module installation error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `facilities_management` module failed to install due to a `ValueError: External ID not found in the system` for `facilities_management.action_maintenance_workorder`. This was caused by a menu item referencing an undefined action. This PR defines the missing `ir.actions.act_window` record, allowing the module to install successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3a30161-cca2-4cbd-9bc3-2754d63b869b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3a30161-cca2-4cbd-9bc3-2754d63b869b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>