### PR TITLE
Install facilities management module with view error

### DIFF
--- a/odoo17/addons/facilities_management/models/sla.py
+++ b/odoo17/addons/facilities_management/models/sla.py
@@ -10,6 +10,7 @@ class FacilitiesSLA(models.Model):
     _name = 'facilities.sla'
     _description = 'Service Level Agreement'
     _order = 'priority desc, name'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     name = fields.Char(string='SLA Name', required=True)
     description = fields.Text(string='Description')
@@ -225,6 +226,7 @@ class FacilitiesSLA(models.Model):
 class SLADashboard(models.Model):
     _name = 'facilities.sla.dashboard'
     _description = 'SLA Performance Dashboard'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     sla_id = fields.Many2one('facilities.sla', string='SLA', required=True)
     date_from = fields.Date(string='From Date', default=fields.Date.today)
@@ -338,6 +340,7 @@ class SLADashboard(models.Model):
 class MaintenanceKPIDashboard(models.Model):
     _name = 'maintenance.kpi.dashboard'
     _description = 'Maintenance KPI Dashboard'
+    _inherit = ['mail.thread', 'mail.activity.mixin']
 
     workorder_id = fields.Many2one('maintenance.workorder', string='Work Order')
     team_id = fields.Many2one('maintenance.team', string='Maintenance Team')


### PR DESCRIPTION
Add `mail.thread` and `mail.activity.mixin` to SLA and dashboard models to enable chatter functionality and resolve module installation errors.

The `ParseError` occurred because the views for `facilities.sla`, `facilities.sla.dashboard`, and `maintenance.kpi.dashboard` models included chatter fields (e.g., `message_follower_ids`) which were not defined in the models. Inheriting from `mail.thread` and `mail.activity.mixin` provides these fields, allowing the module to install correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-085d5b35-dce9-46c1-be05-221345a88819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-085d5b35-dce9-46c1-be05-221345a88819">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>