### PR TITLE
Install facilities management module with post init hook

### DIFF
--- a/odoo17/addons/facilities_management/__init__.py
+++ b/odoo17/addons/facilities_management/__init__.py
@@ -1,2 +1,5 @@
 from . import models
 from . import wizard
+
+# Import the post_init_hook function from models
+from .models import post_init_hook


### PR DESCRIPTION
Import `post_init_hook` in `__init__.py` to resolve module loading error.

The `facilities_management` module failed to load because its `__manifest__.py` referenced a `post_init_hook` function that was defined in `models/__init__.py` but not imported into the top-level `__init__.py`, making it undiscoverable by Odoo's module loading system. This change ensures the hook is properly exposed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7855867-eaf4-4745-aece-434797857e38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7855867-eaf4-4745-aece-434797857e38">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>