### PR TITLE
Odoo server startup and module loading

### DIFF
--- a/odoo17/addons/esg_reporting/README.md
+++ b/odoo17/addons/esg_reporting/README.md
@@ -130,7 +130,6 @@ The ESG Dashboard provides:
 - stock
 - project
 - web
-- web_dashboard
 - spreadsheet_dashboard
 
 ### Assets

--- a/odoo17/addons/esg_reporting/__manifest__.py
+++ b/odoo17/addons/esg_reporting/__manifest__.py
@@ -26,7 +26,6 @@
         'stock',
         'project',
         'web',
-        'web_dashboard',
         'spreadsheet_dashboard',
     ],
     'data': [


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove `web_dashboard` dependency from the ESG Reporting module to fix installation errors in Odoo 17.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `web_dashboard` module is not available in Odoo 17, causing installation failures for `esg_reporting`. This change updates the module to rely on `spreadsheet_dashboard` which is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd08bfdd-4822-448c-b0aa-6bc7e3ff4dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd08bfdd-4822-448c-b0aa-6bc7e3ff4dab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>