### PR TITLE
Install esg reporting module with data error

### DIFF
--- a/odoo17/addons/esg_reporting/models/esg_offset.py
+++ b/odoo17/addons/esg_reporting/models/esg_offset.py
@@ -54,6 +54,7 @@ class ESGOffset(models.Model):
         ('kwh', 'kWh'),
         ('acre', 'Acre'),
         ('hectare', 'Hectare'),
+        ('kg', 'kg'),
     ], string='Unit', required=True, default='t_co2')
     
     offset_amount = fields.Float(
@@ -201,6 +202,7 @@ class ESGOffsetType(models.Model):
         ('tree', 'Tree'),
         ('kwh', 'kWh'),
         ('acre', 'Acre'),
+        ('kg', 'kg'),
         ('hectare', 'Hectare'),
     ], string='Unit', required=True, default='t_co2')
     


### PR DESCRIPTION
Add 'kg' as an allowed unit to `esg.offset` and `esg.offset.type` models.

The `esg_reporting` module failed to install due to a `ValueError` because the `esg_data.xml` file attempted to set the `unit` field to 'kg', which was not a defined selection option in the `unit` field of `esg.offset` and `esg.offset.type` models. This PR adds 'kg' to the allowed selection values for these fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-a429c914-30c7-47f5-98c1-022280ce55e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a429c914-30c7-47f5-98c1-022280ce55e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>