### PR TITLE
Fix esg_emission_form view attributes

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
@@ -30,8 +30,8 @@
             <field name="arch" type="xml">
                 <form string="ESG Analytics">
                     <header>
-                        <button name="action_process" string="Process" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="error"/>
+                        <button name="action_process" string="Process" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'error'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,processing,completed"/>
                     </header>
                     <sheet>
@@ -183,10 +183,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Carbon Footprint">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_emission_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_emission_views.xml
@@ -29,10 +29,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Emission">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_employee_community_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_employee_community_views.xml
@@ -30,10 +30,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Employee Community">
                     <header>
-                        <button name="action_submit" string="Submit" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_approve" string="Approve" type="object" class="oe_highlight" states="submitted"/>
-                        <button name="action_reject" string="Reject" type="object" states="submitted"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="rejected"/>
+                        <button name="action_submit" string="Submit" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_approve" string="Approve" type="object" class="oe_highlight" invisible="state != 'submitted'"/>
+                        <button name="action_reject" string="Reject" type="object" invisible="state != 'submitted'"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'rejected'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,submitted,approved"/>
                     </header>
                     <sheet>
@@ -47,8 +47,8 @@
                                 <field name="date"/>
                                 <field name="employee_id"/>
                                 <field name="activity_type"/>
-                                <field name="commute_type" attrs="{'invisible': [('activity_type', '!=', 'commute')]}"/>
-                                <field name="distance" attrs="{'invisible': [('activity_type', '!=', 'commute')]}"/>
+                                <field name="commute_type" invisible="activity_type != 'commute'"/>
+                                <field name="distance" invisible="activity_type != 'commute'"/>
                             </group>
                             <group>
                                 <field name="duration"/>
@@ -214,10 +214,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Community Initiative">
                     <header>
-                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" states="active"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,active"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" invisible="state != 'active'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'active')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,active,completed"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
@@ -32,10 +32,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Gender Parity">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_initiative_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_initiative_views.xml
@@ -29,11 +29,11 @@
             <field name="arch" type="xml">
                 <form string="ESG Initiative">
                     <header>
-                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_hold" string="Hold" type="object" states="active"/>
-                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" states="active,on_hold"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,active,on_hold"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_hold" string="Hold" type="object" invisible="state != 'active'"/>
+                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" invisible="state not in ('active', 'on_hold')"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'active', 'on_hold')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,active,completed"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_offset_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_offset_views.xml
@@ -30,10 +30,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Offset">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_pay_gap_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_pay_gap_views.xml
@@ -34,10 +34,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Pay Gap">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>


### PR DESCRIPTION
Update Odoo XML views to replace deprecated `attrs` and `states` with `invisible` for Odoo 17.0 compatibility.

This fixes `ParseError` during module installation/update. The error message initially indicated missing fields, but the root cause was the use of `attrs` and `states` attributes, which are deprecated in Odoo 17.0 and must be replaced with `invisible`.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d4ecaf5-48f0-4789-836e-cb8f07bfeaaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d4ecaf5-48f0-4789-836e-cb8f07bfeaaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>