### PR TITLE
Fix esg_reporting view parsing error

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_emission_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_emission_views.xml
@@ -8,10 +8,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Emission">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" states="draft"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" states="confirmed"/>
-                        <button name="action_cancel" string="Cancel" type="object" states="draft,confirmed"/>
-                        <button name="action_draft" string="Set to Draft" type="object" states="cancelled"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
+                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
+                        <button name="action_draft" string="Set to Draft" type="object" invisible="state != 'cancelled'"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>


### PR DESCRIPTION
Update `esg_emission_views.xml` to use `invisible` attribute instead of deprecated `states` for Odoo 17 compatibility.

The `states` attribute for controlling button visibility was deprecated in Odoo 17. This PR replaces it with the `invisible` attribute using domain expressions, as required by Odoo 17.0, to resolve a `ParseError` during module installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-12557cfd-b67b-4e48-a9ca-008d2e338452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12557cfd-b67b-4e48-a9ca-008d2e338452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>