### PR TITLE
Fix esg reporting view field error

### DIFF
--- a/odoo17/addons/esg_reporting/models/esg_analytics.py
+++ b/odoo17/addons/esg_reporting/models/esg_analytics.py
@@ -331,6 +331,13 @@ class ESGCarbonFootprint(models.Model):
         required=True
     )
     
+    state = fields.Selection([
+        ('draft', 'Draft'),
+        ('confirmed', 'Confirmed'),
+        ('validated', 'Validated'),
+        ('cancelled', 'Cancelled'),
+    ], string='Status', default='draft', tracking=True)
+    
     @api.constrains('emission_amount')
     def _check_emission_amount(self):
         for record in self:
@@ -342,3 +349,31 @@ class ESGCarbonFootprint(models.Model):
         for record in self:
             if record.uncertainty < 0 or record.uncertainty > 100:
                 raise ValidationError(_('Uncertainty must be between 0 and 100.'))
+    
+    def action_confirm(self):
+        """Confirm the carbon footprint record"""
+        for record in self:
+            if record.state == 'draft':
+                record.state = 'confirmed'
+        return True
+    
+    def action_validate(self):
+        """Validate the carbon footprint record"""
+        for record in self:
+            if record.state == 'confirmed':
+                record.state = 'validated'
+        return True
+    
+    def action_cancel(self):
+        """Cancel the carbon footprint record"""
+        for record in self:
+            if record.state in ['draft', 'confirmed']:
+                record.state = 'cancelled'
+        return True
+    
+    def action_draft(self):
+        """Reset the carbon footprint record to draft"""
+        for record in self:
+            if record.state == 'cancelled':
+                record.state = 'draft'
+        return True

--- a/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
@@ -158,6 +158,30 @@
             </field>
         </record>
 
+        <!-- ESG Carbon Footprint Search View -->
+        <record id="view_esg_carbon_footprint_search" model="ir.ui.view">
+            <field name="name">esg.carbon.footprint.search</field>
+            <field name="model">esg.carbon.footprint</field>
+            <field name="arch" type="xml">
+                <search string="ESG Carbon Footprint">
+                    <field name="name"/>
+                    <field name="scope"/>
+                    <field name="emission_source"/>
+                    <field name="date"/>
+                    <filter string="Draft" name="draft" domain="[('state', '=', 'draft')]"/>
+                    <filter string="Confirmed" name="confirmed" domain="[('state', '=', 'confirmed')]"/>
+                    <filter string="Validated" name="validated" domain="[('state', '=', 'validated')]"/>
+                    <filter string="Cancelled" name="cancelled" domain="[('state', '=', 'cancelled')]"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Scope" name="scope" context="{'group_by': 'scope'}"/>
+                        <filter string="Emission Source" name="emission_source" context="{'group_by': 'emission_source'}"/>
+                        <filter string="State" name="state" context="{'group_by': 'state'}"/>
+                        <filter string="Verification Status" name="verification_status" context="{'group_by': 'verification_status'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
         <!-- ESG Carbon Footprint List View -->
         <record id="view_esg_carbon_footprint_list" model="ir.ui.view">
             <field name="name">esg.carbon.footprint.list</field>


### PR DESCRIPTION
Add `state` field and workflow actions to `esg.carbon.footprint` model and a related search view to fix a module installation error.

The module failed to install due to a `ParseError` because the `esg_analytics_views.xml` file referenced a `state` field and associated action methods that were not defined in the `esg.carbon.footprint` model.

---
<a href="https://cursor.com/background-agent?bcId=bc-64b339b2-5c7e-4371-8a4b-e61cc0fed930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64b339b2-5c7e-4371-8a4b-e61cc0fed930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>