### PR TITLE
Fix unknown month field in gender parity view

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
@@ -142,8 +142,7 @@
                         <filter string="Department" name="department" context="{'group_by': 'department_id'}"/>
                         <filter string="Job Position" name="job" context="{'group_by': 'job_id'}"/>
                         <filter string="Period Type" name="period_type" context="{'group_by': 'period_type'}"/>
-                        <filter string="Month" name="month" context="{'group_by': 'month'}"/>
-                        <filter string="Year" name="year" context="{'group_by': 'year'}"/>
+                        <filter string="Date" name="date" context="{'group_by': 'date'}"/>
                     </group>
                 </search>
             </field>


### PR DESCRIPTION
```
Replaces non-existent 'month' and 'year' group-by filters with 'date' in ESG gender parity search view to fix ParseError.
```

---
<a href="https://cursor.com/background-agent?bcId=bc-7b19bc86-2ba2-4825-8ee9-6364a05f17d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b19bc86-2ba2-4825-8ee9-6364a05f17d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>