### PR TITLE
Fix esg framework view field error

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_framework_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_framework_views.xml
@@ -78,7 +78,7 @@
                     </sheet>
                     <div class="oe_chatter">
                         <field name="message_follower_ids"/>
-                        <field name="activity_purchase_ids"/>
+                        <field name="activity_ids"/>
                     </div>
                 </form>
             </field>


### PR DESCRIPTION
Fix ParseError by replacing `activity_purchase_ids` with `activity_ids` in ESG framework view.

The `esg.framework` model inherits `mail.activity.mixin`, which provides the `activity_ids` field for chatter functionality. The view incorrectly referenced `activity_purchase_ids`, leading to a validation error during module loading.

---
<a href="https://cursor.com/background-agent?bcId=bc-d757faa0-fe14-4f56-80b6-ad1ff60fb4d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d757faa0-fe14-4f56-80b6-ad1ff60fb4d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>