### PR TITLE
Fix esg framework view field error

### DIFF
--- a/odoo17/addons/esg_reporting/models/__init__.py
+++ b/odoo17/addons/esg_reporting/models/__init__.py
@@ -7,3 +7,4 @@ from . import esg_gender_parity
 from . import esg_pay_gap
 from . import esg_framework
 from . import esg_target
+from . import purchase_order

--- a/odoo17/addons/esg_reporting/models/esg_framework.py
+++ b/odoo17/addons/esg_reporting/models/esg_framework.py
@@ -125,6 +125,14 @@ class ESGFramework(models.Model):
         required=True
     )
     
+    # Purchase Activities (for ESG-related purchases)
+    activity_purchase_ids = fields.One2many(
+        'purchase.order',
+        'esg_framework_id',
+        string='Purchase Activities',
+        help="Purchase orders related to ESG framework activities"
+    )
+    
     @api.constrains('materiality_threshold')
     def _check_materiality_threshold(self):
         for record in self:

--- a/odoo17/addons/esg_reporting/models/purchase_order.py
+++ b/odoo17/addons/esg_reporting/models/purchase_order.py
@@ -1,0 +1,11 @@
+from odoo import models, fields, api
+
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+    
+    esg_framework_id = fields.Many2one(
+        'esg.framework',
+        string='ESG Framework',
+        help="ESG framework this purchase order is related to"
+    )


### PR DESCRIPTION
Add missing `activity_purchase_ids` field to `esg.framework` to resolve module upgrade error.

The module upgrade failed with a `ParseError` indicating that the `activity_purchase_ids` field did not exist in the `esg.framework` model, likely due to a cached view definition. This PR adds the necessary `One2many` field to `esg.framework` and a corresponding `Many2one` field to `purchase.order` to resolve this validation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-16c82c37-f871-4cf9-982c-5a2ead6a09ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16c82c37-f871-4cf9-982c-5a2ead6a09ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>