### PR TITLE
Fix invalid xml and missing template

### DIFF
--- a/facilities_management_module/reports/esg_report_pdf.xml
+++ b/facilities_management_module/reports/esg_report_pdf.xml
@@ -62,7 +62,7 @@
                                 <td>
                                     <t t-if="data.get('report_type') == 'environmental'">Environmental Impact</t>
                                     <t t-elif="data.get('report_type') == 'social'">Social Impact</t>
-                                    <t t-elif="data.get('report_type') == 'governance'">Governance & Compliance</t>
+                                    <t t-elif="data.get('report_type') == 'governance'">Governance &amp; Compliance</t>
                                     <t t-else="">Comprehensive ESG</t>
                                 </td>
                             </tr>

--- a/odoo17/addons/esg_reporting/static/src/xml/esg_advanced_dashboard.xml
+++ b/odoo17/addons/esg_reporting/static/src/xml/esg_advanced_dashboard.xml
@@ -186,7 +186,7 @@
                     <div class="col-md-4">
                         <div class="card">
                             <div class="card-header">
-                                <h5 class="card-title mb-0">Alerts & Notifications</h5>
+                                <h5 class="card-title mb-0">Alerts &amp; Notifications</h5>
                             </div>
                             <div class="card-body">
                                 <div class="alerts-container" style="max-height: 300px; overflow-y: auto;">


### PR DESCRIPTION
Escape ampersands in XML templates to fix parsing errors and allow the apps page to load.

The browser console showed `Uncaught Error: Invalid XML template: ... xmlParseEntityRef: no name` and `OwlError: Missing template: "web.WebClient"`. These errors were caused by unescaped `&` characters in the XML, which are invalid and led to the subsequent template loading failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-132b9ec3-8287-4d3a-bc8e-676984df2bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-132b9ec3-8287-4d3a-bc8e-676984df2bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>