### PR TITLE
Fix view parsing error for attrs and states

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_analytics_views.xml
@@ -30,8 +30,8 @@
             <field name="arch" type="xml">
                 <form string="ESG Analytics">
                     <header>
-                        <button name="action_process" string="Process" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'error'"/>
+                        <button name="action_process" string="Process" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'error')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,processing,completed"/>
                     </header>
                     <sheet>
@@ -207,10 +207,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Carbon Footprint">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'confirmed'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_emission_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_emission_views.xml
@@ -8,10 +8,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Emission">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
-                        <button name="action_draft" string="Set to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'confirmed'])]}"/>
+                        <button name="action_draft" string="Set to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_employee_community_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_employee_community_views.xml
@@ -30,10 +30,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Employee Community">
                     <header>
-                        <button name="action_submit" string="Submit" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_approve" string="Approve" type="object" class="oe_highlight" invisible="state != 'submitted'"/>
-                        <button name="action_reject" string="Reject" type="object" invisible="state != 'submitted'"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'rejected'"/>
+                        <button name="action_submit" string="Submit" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_approve" string="Approve" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'submitted')]}"/>
+                        <button name="action_reject" string="Reject" type="object" attrs="{'invisible': [('state', '!=', 'submitted')]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'rejected')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,submitted,approved"/>
                     </header>
                     <sheet>
@@ -47,8 +47,8 @@
                                 <field name="date"/>
                                 <field name="employee_id"/>
                                 <field name="activity_type"/>
-                                <field name="commute_type" invisible="activity_type != 'commute'"/>
-                                <field name="distance" invisible="activity_type != 'commute'"/>
+                                <field name="commute_type" attrs="{'invisible': [('activity_type', '!=', 'commute')]}"/>
+                                <field name="distance" attrs="{'invisible': [('activity_type', '!=', 'commute')]}"/>
                             </group>
                             <group>
                                 <field name="duration"/>
@@ -214,10 +214,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Community Initiative">
                     <header>
-                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" invisible="state != 'active'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'active')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'active')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'active'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,active,completed"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_framework_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_framework_views.xml
@@ -233,10 +233,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Materiality Assessment">
                     <header>
-                        <button name="action_start_assessment" string="Start Assessment" type="object" class="btn-primary" invisible="state != 'draft'"/>
-                        <button name="action_complete_assessment" string="Complete Assessment" type="object" class="btn-success" invisible="state != 'in_progress'"/>
-                        <button name="action_validate_assessment" string="Validate" type="object" class="btn-warning" invisible="state != 'completed'"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state not in ('in_progress','completed','validated')"/>
+                        <button name="action_start_assessment" string="Start Assessment" type="object" class="btn-primary" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_complete_assessment" string="Complete Assessment" type="object" class="btn-success" attrs="{'invisible': [('state', '!=', 'in_progress')]}"/>
+                        <button name="action_validate_assessment" string="Validate" type="object" class="btn-warning" attrs="{'invisible': [('state', '!=', 'completed')]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', 'not in', ['in_progress','completed','validated'])]}"/>
                         <field name="state" widget="statusbar"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_gender_parity_views.xml
@@ -32,10 +32,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Gender Parity">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'confirmed'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_initiative_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_initiative_views.xml
@@ -29,11 +29,11 @@
             <field name="arch" type="xml">
                 <form string="ESG Initiative">
                     <header>
-                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_hold" string="Hold" type="object" invisible="state != 'active'"/>
-                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" invisible="state not in ('active', 'on_hold')"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'active', 'on_hold')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_activate" string="Activate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_hold" string="Hold" type="object" attrs="{'invisible': [('state', '!=', 'active')]}"/>
+                        <button name="action_complete" string="Complete" type="object" class="oe_highlight" attrs="{'invisible': [('state', 'not in', ['active', 'on_hold'])]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'active', 'on_hold'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,active,completed"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_offset_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_offset_views.xml
@@ -30,10 +30,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Offset">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'confirmed'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_pay_gap_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_pay_gap_views.xml
@@ -34,10 +34,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Pay Gap">
                     <header>
-                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" invisible="state != 'draft'"/>
-                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" invisible="state != 'confirmed'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft', 'confirmed')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state != 'cancelled'"/>
+                        <button name="action_confirm" string="Confirm" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_validate" string="Validate" type="object" class="oe_highlight" attrs="{'invisible': [('state', '!=', 'confirmed')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft', 'confirmed'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', '!=', 'cancelled')]}"/>
                         <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,validated"/>
                     </header>
                     <sheet>

--- a/odoo17/addons/esg_reporting/views/esg_target_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_target_views.xml
@@ -29,12 +29,12 @@
             <field name="arch" type="xml">
                 <form string="ESG Target">
                     <header>
-                        <button name="action_activate" string="Activate" type="object" class="btn-primary" invisible="state != 'draft'"/>
-                        <button name="action_achieve" string="Mark Achieved" type="object" class="btn-success" invisible="state != 'active'"/>
-                        <button name="action_at_risk" string="Mark At Risk" type="object" class="btn-warning" invisible="state != 'active'"/>
-                        <button name="action_missed" string="Mark Missed" type="object" class="btn-danger" invisible="state not in ('active','at_risk')"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state not in ('draft','active')"/>
-                        <button name="action_draft" string="Reset to Draft" type="object" invisible="state not in ('cancelled','missed')"/>
+                        <button name="action_activate" string="Activate" type="object" class="btn-primary" attrs="{'invisible': [('state', '!=', 'draft')]}"/>
+                        <button name="action_achieve" string="Mark Achieved" type="object" class="btn-success" attrs="{'invisible': [('state', '!=', 'active')]}"/>
+                        <button name="action_at_risk" string="Mark At Risk" type="object" class="btn-warning" attrs="{'invisible': [('state', '!=', 'active')]}"/>
+                        <button name="action_missed" string="Mark Missed" type="object" class="btn-danger" attrs="{'invisible': [('state', 'not in', ['active','at_risk'])]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', 'not in', ['draft','active'])]}"/>
+                        <button name="action_draft" string="Reset to Draft" type="object" attrs="{'invisible': [('state', 'not in', ['cancelled','missed'])]}"/>
                         <field name="state" widget="statusbar"/>
                     </header>
                     <sheet>
@@ -183,10 +183,10 @@
             <field name="arch" type="xml">
                 <form string="ESG Target Milestone">
                     <header>
-                        <button name="action_achieve" string="Mark Achieved" type="object" class="btn-success" invisible="state != 'pending'"/>
-                        <button name="action_miss" string="Mark Missed" type="object" class="btn-danger" invisible="state != 'pending'"/>
-                        <button name="action_cancel" string="Cancel" type="object" invisible="state != 'pending'"/>
-                        <button name="action_pending" string="Reset to Pending" type="object" invisible="state not in ('achieved','missed','cancelled')"/>
+                        <button name="action_achieve" string="Mark Achieved" type="object" class="btn-success" attrs="{'invisible': [('state', '!=', 'pending')]}"/>
+                        <button name="action_miss" string="Mark Missed" type="object" class="btn-danger" attrs="{'invisible': [('state', '!=', 'pending')]}"/>
+                        <button name="action_cancel" string="Cancel" type="object" attrs="{'invisible': [('state', '!=', 'pending')]}"/>
+                        <button name="action_pending" string="Reset to Pending" type="object" attrs="{'invisible': [('state', 'not in', ['achieved','missed','cancelled'])]}"/>
                         <field name="state" widget="statusbar"/>
                     </header>
                     <sheet>


### PR DESCRIPTION
Update Odoo XML views to use `attrs` instead of deprecated `invisible` and `states` attributes.

---
<a href="https://cursor.com/background-agent?bcId=bc-9468a432-1696-4f50-bec1-5b44f9d30fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9468a432-1696-4f50-bec1-5b44f9d30fd6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>