### PR TITLE
Fix missing sequence field in esg target milestone view

### DIFF
--- a/odoo17/addons/esg_reporting/data/esg_demo.xml
+++ b/odoo17/addons/esg_reporting/data/esg_demo.xml
@@ -163,6 +163,7 @@
             <field name="expected_value">750.0</field>
             <field name="actual_value">720.0</field>
             <field name="state">achieved</field>
+            <field name="sequence">10</field>
             <field name="notes">Achieved 28% reduction by 2025, exceeding the expected 25% milestone.</field>
         </record>
 
@@ -173,6 +174,7 @@
             <field name="expected_value">625.0</field>
             <field name="actual_value">0.0</field>
             <field name="state">pending</field>
+            <field name="sequence">20</field>
             <field name="notes">Target: 37.5% reduction by 2027</field>
         </record>
 
@@ -183,6 +185,7 @@
             <field name="expected_value">30.0</field>
             <field name="actual_value">32.0</field>
             <field name="state">achieved</field>
+            <field name="sequence">10</field>
             <field name="notes">Exceeded the 2024 target of 30% women in leadership positions.</field>
         </record>
 

--- a/odoo17/addons/esg_reporting/models/esg_target.py
+++ b/odoo17/addons/esg_reporting/models/esg_target.py
@@ -370,11 +370,17 @@ class ESGTarget(models.Model):
 class ESGTargetMilestone(models.Model):
     _name = 'esg.target.milestone'
     _description = 'ESG Target Milestone'
-    _order = 'target_id, date'
+    _order = 'target_id, sequence, date'
 
     name = fields.Char(
         string='Milestone Name',
         required=True
+    )
+    
+    sequence = fields.Integer(
+        string='Sequence',
+        default=10,
+        help="Determines the order of milestones"
     )
     
     target_id = fields.Many2one(

--- a/odoo17/addons/esg_reporting/views/esg_target_views.xml
+++ b/odoo17/addons/esg_reporting/views/esg_target_views.xml
@@ -163,6 +163,7 @@
             <field name="model">esg.target.milestone</field>
             <field name="arch" type="xml">
                 <tree string="ESG Target Milestones">
+                    <field name="sequence" widget="handle"/>
                     <field name="target_id"/>
                     <field name="name"/>
                     <field name="date"/>


### PR DESCRIPTION
Add missing `sequence` field to `esg.target.milestone` model and views to resolve a `ParseError` during module upgrade.

---
<a href="https://cursor.com/background-agent?bcId=bc-d72e1efb-4040-45e5-ac41-b397d5c1c460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d72e1efb-4040-45e5-ac41-b397d5c1c460">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>