### PR TITLE
Fix facilities management template download import error

### DIFF
--- a/odoo17/addons/facilities_management/models/facilities_import_wizard.py
+++ b/odoo17/addons/facilities_management/models/facilities_import_wizard.py
@@ -23,7 +23,7 @@ class FacilitiesImportWizard(models.TransientModel):
         ('assets', 'Assets')
     ], string='Import Type', required=True, default='facilities')
     
-    import_file = fields.Binary(string='Import File', required=True)
+    import_file = fields.Binary(string='Import File', required=False)
     import_filename = fields.Char(string='Filename')
     file_type = fields.Selection([
         ('csv', 'CSV'),


### PR DESCRIPTION
Make `import_file` field optional to fix "invalid fields" error when downloading templates.

---
<a href="https://cursor.com/background-agent?bcId=bc-19fd99dc-77e7-4166-a711-603d107ee152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19fd99dc-77e7-4166-a711-603d107ee152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>