### PR TITLE
Odoo menu item external id not found

### DIFF
--- a/odoo17/addons/esg_reporting/views/esg_report_menus.xml
+++ b/odoo17/addons/esg_reporting/views/esg_report_menus.xml
@@ -4,7 +4,7 @@
         <!-- Enhanced ESG Reports Menu -->
         <menuitem id="menu_enhanced_esg_reports"
                   name="Enhanced ESG Reports"
-                  parent="facilities_management_module.menu_facilities_management"
+                  parent="facilities_management.menu_facilities_root"
                   sequence="20"/>
 
         <!-- Enhanced ESG Report Wizard Menu -->


### PR DESCRIPTION
Update parent menu ID in `esg_report_menus.xml` to fix module installation.

The `esg_reporting` module failed to load because its menu item referenced a non-existent parent ID (`facilities_management_module.menu_facilities_management`). This PR corrects the reference to `facilities_management.menu_facilities_root`, which is the correct and existing menu in the `facilities_management` module.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f90ad2e-481b-4cb2-993b-d9015d30facd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f90ad2e-481b-4cb2-993b-d9015d30facd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>