### PR TITLE
Handle esg_advanced_dashboard key not found error

### DIFF
--- a/odoo17/addons/esg_reporting/__manifest__.py
+++ b/odoo17/addons/esg_reporting/__manifest__.py
@@ -33,6 +33,7 @@
     'data': [
         'security/esg_security.xml',
         'security/ir.model.access.csv',
+        'views/assets.xml',
         'views/esg_offset_views.xml',
         'views/esg_emission_views.xml',
         'views/esg_employee_community_views.xml',

--- a/odoo17/addons/esg_reporting/views/assets.xml
+++ b/odoo17/addons/esg_reporting/views/assets.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <template id="assets_backend" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/esg_reporting/static/src/js/esg_advanced_dashboard.js"/>
+                <script type="text/javascript" src="/esg_reporting/static/src/js/esg_dashboard.js"/>
+            </xpath>
+        </template>
+    </data>
+</odoo>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add assets definition for `esg_advanced_dashboard.js` and `esg_dashboard.js` to resolve `KeyNotFoundError`.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `esg_advanced_dashboard` was not found in the registry because its JavaScript file was not being loaded by the Odoo module. This PR introduces an `assets.xml` file to properly include the necessary JavaScript files (`esg_advanced_dashboard.js` and `esg_dashboard.js`) in the `web.assets_backend` bundle and updates the `__manifest__.py` to reference this new assets file.

---
<a href="https://cursor.com/background-agent?bcId=bc-0606cf5e-2e2d-404d-a1f6-4072095fd35b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0606cf5e-2e2d-404d-a1f6-4072095fd35b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>