### PR TITLE
Fix qweb template name access error

### DIFF
--- a/ESG_TEMPLATE_SECURITY_FIX.md
+++ b/ESG_TEMPLATE_SECURITY_FIX.md
@@ -1,0 +1,66 @@
+# ESG Template Security Fix
+
+## Problem
+The ESG reporting template was causing a `NameError: Access to forbidden name '__name__'` error when trying to compile the QWeb template. This occurred because Odoo's safe evaluation context prohibits access to dunder methods (methods starting and ending with double underscores) for security reasons.
+
+## Error Details
+```
+NameError: Access to forbidden name '__name__' ("type(report_data).__name__ if report_data else 'None'")
+Template: esg_reporting.report_enhanced_esg_wizard_document
+Path: /t/div/div[2]/div/div/div/p[3]/t
+Node: <t t-esc="type(report_data).__name__ if report_data else 'None'"/>
+```
+
+## Root Cause
+The problematic line was in the debug information section of the template:
+```xml
+<p><strong>Report data type:</strong> <t t-esc="type(report_data).__name__ if report_data else 'None'"/></p>
+```
+
+This line attempted to access the `__name__` attribute of the type object, which is forbidden in Odoo's safe evaluation context.
+
+## Solution
+Replaced the forbidden `type(report_data).__name__` access with a safe alternative using `isinstance()` checks:
+
+### Before (Problematic):
+```xml
+<p><strong>Report data type:</strong> <t t-esc="type(report_data).__name__ if report_data else 'None'"/></p>
+```
+
+### After (Fixed):
+```xml
+<p><strong>Report data type:</strong> <t t-esc="'dict' if isinstance(report_data, dict) else 'list' if isinstance(report_data, list) else 'str' if isinstance(report_data, str) else 'int' if isinstance(report_data, int) else 'float' if isinstance(report_data, float) else 'bool' if isinstance(report_data, bool) else 'None' if report_data is None else 'other'"/></p>
+```
+
+## Additional Safety Improvements
+Also added safety checks for other potentially problematic accesses:
+
+### Before:
+```xml
+<p><strong>Report data keys:</strong> <t t-esc="list(report_data.keys()) if report_data else 'None'"/></p>
+<p><strong>Wizard object keys:</strong> <t t-esc="list(o._fields.keys()) if o else 'None'"/></p>
+```
+
+### After:
+```xml
+<p><strong>Report data keys:</strong> <t t-esc="list(report_data.keys()) if report_data and hasattr(report_data, 'keys') else 'None'"/></p>
+<p><strong>Wizard object keys:</strong> <t t-esc="list(o._fields.keys()) if o and hasattr(o, '_fields') else 'None'"/></p>
+```
+
+## Benefits
+1. **Security**: Eliminates access to forbidden dunder methods
+2. **Compatibility**: Uses only safe functions allowed in Odoo's evaluation context
+3. **Robustness**: Added `hasattr()` checks to prevent attribute access errors
+4. **Functionality**: Maintains the same debugging information but in a secure way
+
+## Verification
+- ✅ Template security check passed
+- ✅ No forbidden patterns found in the template
+- ✅ The fix maintains the same debugging functionality
+- ✅ Template should now compile without security errors
+
+## Files Modified
+- `odoo17/addons/esg_reporting/report/esg_report_templates.xml` (lines 370-372)
+
+## Testing
+The fix has been verified using a custom security checker that scans for forbidden patterns in QWeb templates. The template now passes all security checks and should compile successfully in Odoo.

--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -368,9 +368,9 @@
                                 <h4>Debug Information</h4>
                                 <p><strong>Wizard report_data exists:</strong> <t t-esc="'Yes' if o.report_data else 'No'"/></p>
                                 <p><strong>Report data exists:</strong> <t t-esc="'Yes' if report_data else 'No'"/></p>
-                                <p><strong>Report data type:</strong> <t t-esc="type(report_data).__name__ if report_data else 'None'"/></p>
-                                <p><strong>Report data keys:</strong> <t t-esc="list(report_data.keys()) if report_data else 'None'"/></p>
-                                <p><strong>Wizard object keys:</strong> <t t-esc="list(o._fields.keys()) if o else 'None'"/></p>
+                                <p><strong>Report data type:</strong> <t t-esc="'dict' if isinstance(report_data, dict) else 'list' if isinstance(report_data, list) else 'str' if isinstance(report_data, str) else 'int' if isinstance(report_data, int) else 'float' if isinstance(report_data, float) else 'bool' if isinstance(report_data, bool) else 'None' if report_data is None else 'other'"/></p>
+                                <p><strong>Report data keys:</strong> <t t-esc="list(report_data.keys()) if report_data and hasattr(report_data, 'keys') else 'None'"/></p>
+                                <p><strong>Wizard object keys:</strong> <t t-esc="list(o._fields.keys()) if o and hasattr(o, '_fields') else 'None'"/></p>
                             </div>
                             
                             <t t-if="report_data and report_data.get('report_info')">

--- a/test_template_fix.py
+++ b/test_template_fix.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Test script to verify the ESG reporting template fix.
+This script tests that the template no longer contains forbidden __name__ access.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+def check_template_security(template_path):
+    """Check if the template contains any forbidden patterns."""
+    forbidden_patterns = [
+        r'\.__name__',  # Access to __name__ attribute
+        r'\.__[a-zA-Z_]+__',  # Any dunder method access
+        r'__import__',  # Import function
+        r'eval\s*\(',  # Eval function
+        r'exec\s*\(',  # Exec function
+        r'globals\s*\(',  # Globals function
+        r'locals\s*\(',  # Locals function
+    ]
+    
+    try:
+        with open(template_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        issues = []
+        for pattern in forbidden_patterns:
+            matches = re.finditer(pattern, content, re.IGNORECASE)
+            for match in matches:
+                line_num = content[:match.start()].count('\n') + 1
+                issues.append(f"Line {line_num}: {match.group()}")
+        
+        if issues:
+            print(f"❌ Security issues found in {template_path}:")
+            for issue in issues:
+                print(f"  - {issue}")
+            return False
+        else:
+            print(f"✅ No security issues found in {template_path}")
+            return True
+            
+    except FileNotFoundError:
+        print(f"❌ Template file not found: {template_path}")
+        return False
+    except Exception as e:
+        print(f"❌ Error checking template: {e}")
+        return False
+
+def main():
+    """Main function to test the template fix."""
+    template_path = "odoo17/addons/esg_reporting/report/esg_report_templates.xml"
+    
+    print("Testing ESG reporting template security...")
+    print("=" * 50)
+    
+    success = check_template_security(template_path)
+    
+    print("\n" + "=" * 50)
+    if success:
+        print("✅ Template security check passed!")
+        print("The __name__ access issue has been fixed.")
+        print("The template should now compile without security errors.")
+    else:
+        print("❌ Template security check failed!")
+        print("Please review and fix the identified issues.")
+    
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replace forbidden `__name__` access with safe `isinstance` checks in ESG report template to resolve QWeb compilation error.

The `NameError` occurred because Odoo's QWeb safe evaluation context prohibits direct access to dunder attributes like `__name__`. The fix replaces this with `isinstance` checks and adds `hasattr` for robustness, ensuring the template compiles securely while maintaining debugging functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-125620b9-9e6a-4798-9995-492236672e7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-125620b9-9e6a-4798-9995-492236672e7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>