### PR TITLE
Fix xml tag mismatch in esg report

### DIFF
--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -387,19 +387,6 @@
                                 <p>This enhanced ESG report provides comprehensive analysis of environmental, social, and governance performance with advanced analytics and insights.</p>
                                 <p><strong>Total Assets Analyzed:</strong> <t t-esc="report_info.get('total_assets', 0)"/></p>
                                 <p><strong>Report Theme:</strong> <t t-esc="report_info.get('theme', 'Default')"/></p>
-                            </t>
-                            <t t-else="">
-                                <div class="alert alert-warning" role="alert">
-                                    <h4>No Report Data Available</h4>
-                                    <p>The report data could not be generated. This might be due to:</p>
-                                    <ul>
-                                        <li>No assets found matching the specified criteria</li>
-                                        <li>Data processing error</li>
-                                        <li>Configuration issues</li>
-                                    </ul>
-                                    <p>Please check your report settings and try again.</p>
-                                </div>
-                            </t>
                                 
                                 <!-- Environmental Metrics -->
                                 <t t-if="o.include_section_environmental and report_data.get('environmental_metrics')">
@@ -518,6 +505,18 @@
                                     </div>
                                 </t>
                                 
+                            </t>
+                            <t t-else="">
+                                <div class="alert alert-warning" role="alert">
+                                    <h4>No Report Data Available</h4>
+                                    <p>The report data could not be generated. This might be due to:</p>
+                                    <ul>
+                                        <li>No assets found matching the specified criteria</li>
+                                        <li>Data processing error</li>
+                                        <li>Configuration issues</li>
+                                    </ul>
+                                    <p>Please check your report settings and try again.</p>
+                                </div>
                             </t>
                             
                             <h3>Report Configuration</h3>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move `t-else` block in `esg_report_templates.xml` to fix XML syntax error due to incorrect conditional nesting.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it's fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original XML structure prematurely closed the `<t t-if="report_data and report_data.get('report_info')">` block. This caused subsequent report sections (Environmental, Social, Governance Metrics) to be outside the conditional, leading to an `XMLSyntaxError` during module upgrade. The `t-else` block was moved to ensure all report content is properly nested within the `t-if` condition.

---
<a href="https://cursor.com/background-agent?bcId=bc-368787cd-624d-49c3-8991-58117147c862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-368787cd-624d-49c3-8991-58117147c862">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>