### PR TITLE
Fix missing chart status in report

### DIFF
--- a/odoo17/addons/facilities_management/reports/monthly_building_report_pdf.xml
+++ b/odoo17/addons/facilities_management/reports/monthly_building_report_pdf.xml
@@ -21,36 +21,66 @@
                     <tr>
                         <td style="vertical-align:top; width:33%;">
                             <h3>Status Distribution</h3>
-                            <img t-att-src="'data:image/png;base64,%s' % doc['chart_status']" style="max-width:100%;"/>
+                            <t t-if="doc['chart_status']">
+                                <img t-att-src="'data:image/png;base64,%s' % doc['chart_status']" style="max-width:100%;"/>
+                            </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                         <td style="vertical-align:top; width:33%;">
                             <h3>Work Orders by Type</h3>
-                            <img t-att-src="'data:image/png;base64,%s' % doc['chart_type']" style="max-width:100%;"/>
+                            <t t-if="doc['chart_type']">
+                                <img t-att-src="'data:image/png;base64,%s' % doc['chart_type']" style="max-width:100%;"/>
+                            </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                         <td style="vertical-align:top; width:33%;">
                             <h3>Work Orders by Priority</h3>
-                            <img t-att-src="'data:image/png;base64,%s' % doc['chart_priority']" style="max-width:100%;"/>
+                            <t t-if="doc['chart_priority']">
+                                <img t-att-src="'data:image/png;base64,%s' % doc['chart_priority']" style="max-width:100%;"/>
+                            </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                     </tr>
                     <tr>
                         <td style="vertical-align:top;">
                             <h3>Work Orders by Day</h3>
-                            <img t-att-src="'data:image/png;base64,%s' % doc['chart_days']" style="max-width:100%;"/>
+                            <t t-if="doc['chart_days']">
+                                <img t-att-src="'data:image/png;base64,%s' % doc['chart_days']" style="max-width:100%;"/>
+                            </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                         <td style="vertical-align:top;">
                             <h3>SLA Compliance</h3>
-                            <img t-att-src="'data:image/png;base64,%s' % doc['chart_sla']" style="max-width:100%;"/>
+                            <t t-if="doc['chart_sla']">
+                                <img t-att-src="'data:image/png;base64,%s' % doc['chart_sla']" style="max-width:100%;"/>
+                            </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                         <td style="vertical-align:top;">
                             <h3>Wordcloud</h3>
                             <t t-if="doc['chart_wordcloud']">
                                 <img t-att-src="'data:image/png;base64,%s' % doc['chart_wordcloud']" style="max-width:100%;"/>
                             </t>
+                            <t t-else="">
+                                <p><em>No data available</em></p>
+                            </t>
                         </td>
                     </tr>
                 </table>
                 <h3>Top 5 Assets</h3>
-                <img t-att-src="'data:image/png;base64,%s' % doc['chart_assets']" style="max-width:500px;"/>
+                <t t-if="doc['chart_assets']">
+                    <img t-att-src="'data:image/png;base64,%s' % doc['chart_assets']" style="max-width:500px;"/>
+                </t>
                 <table class="table table-sm">
                     <tr><th>Asset</th><th>Work Orders</th></tr>
                     <t t-foreach="doc['top_assets']" t-as="a">
@@ -58,7 +88,9 @@
                     </t>
                 </table>
                 <h3>Top 5 Rooms</h3>
-                <img t-att-src="'data:image/png;base64,%s' % doc['chart_rooms']" style="max-width:500px;"/>
+                <t t-if="doc['chart_rooms']">
+                    <img t-att-src="'data:image/png;base64,%s' % doc['chart_rooms']" style="max-width:500px;"/>
+                </t>
                 <table class="table table-sm">
                     <tr><th>Room</th><th>Work Orders</th></tr>
                     <t t-foreach="doc['top_rooms']" t-as="r">
@@ -66,7 +98,9 @@
                     </t>
                 </table>
                 <h3>Top 5 Parts Used</h3>
-                <img t-att-src="'data:image/png;base64,%s' % doc['chart_parts']" style="max-width:500px;"/>
+                <t t-if="doc['chart_parts']">
+                    <img t-att-src="'data:image/png;base64,%s' % doc['chart_parts']" style="max-width:500px;"/>
+                </t>
                 <table class="table table-sm">
                     <tr><th>Part</th><th>Qty Used</th></tr>
                     <t t-foreach="doc['top_parts']" t-as="p">

--- a/odoo17/addons/facilities_management/wizard/monthly_building_report_wizard.py
+++ b/odoo17/addons/facilities_management/wizard/monthly_building_report_wizard.py
@@ -3,6 +3,10 @@ from datetime import datetime
 import io, base64
 from collections import Counter
 import calendar
+import matplotlib
+matplotlib.use('Agg')  # Use non-interactive backend
+import matplotlib.pyplot as plt
+import numpy as np
 
 class MonthlyBuildingReportWizard(models.TransientModel):
     _name = 'monthly.building.report.wizard'
@@ -13,6 +17,68 @@ class MonthlyBuildingReportWizard(models.TransientModel):
     month = fields.Selection(
         [(str(i), calendar.month_name[i]) for i in range(1, 13)],
         string='Month', required=True, default=lambda self: str(datetime.now().month))
+
+    def _generate_pie_chart(self, data, title):
+        """Generate a pie chart and return as base64 string"""
+        if not data:
+            return None
+        
+        plt.figure(figsize=(8, 6))
+        plt.pie(data.values(), labels=data.keys(), autopct='%1.1f%%', startangle=90)
+        plt.title(title)
+        plt.axis('equal')
+        
+        # Save to bytes buffer
+        buffer = io.BytesIO()
+        plt.savefig(buffer, format='png', bbox_inches='tight', dpi=100)
+        buffer.seek(0)
+        plt.close()
+        
+        return base64.b64encode(buffer.getvalue()).decode()
+
+    def _generate_bar_chart(self, data, title, xlabel='', ylabel=''):
+        """Generate a bar chart and return as base64 string"""
+        if not data:
+            return None
+        
+        plt.figure(figsize=(10, 6))
+        plt.bar(range(len(data)), list(data.values()))
+        plt.title(title)
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        plt.xticks(range(len(data)), list(data.keys()), rotation=45, ha='right')
+        plt.tight_layout()
+        
+        # Save to bytes buffer
+        buffer = io.BytesIO()
+        plt.savefig(buffer, format='png', bbox_inches='tight', dpi=100)
+        buffer.seek(0)
+        plt.close()
+        
+        return base64.b64encode(buffer.getvalue()).decode()
+
+    def _generate_line_chart(self, data, title, xlabel='', ylabel=''):
+        """Generate a line chart and return as base64 string"""
+        if not data:
+            return None
+        
+        plt.figure(figsize=(10, 6))
+        x = list(data.keys())
+        y = list(data.values())
+        plt.plot(x, y, marker='o')
+        plt.title(title)
+        plt.xlabel(xlabel)
+        plt.ylabel(ylabel)
+        plt.grid(True, alpha=0.3)
+        plt.tight_layout()
+        
+        # Save to bytes buffer
+        buffer = io.BytesIO()
+        plt.savefig(buffer, format='png', bbox_inches='tight', dpi=100)
+        buffer.seek(0)
+        plt.close()
+        
+        return base64.b64encode(buffer.getvalue()).decode()
 
     def action_generate_pdf_report(self):
         year, month = int(self.year), int(self.month)
@@ -100,6 +166,26 @@ class MonthlyBuildingReportWizard(models.TransientModel):
         top_parts = parts_counts.most_common(5)
         top_issues = issue_counts.most_common(5)
 
+        # Generate charts
+        chart_status = self._generate_pie_chart(status_counts_friendly, 'Work Orders by Status')
+        chart_type = self._generate_pie_chart(type_counts_friendly, 'Work Orders by Type')
+        chart_priority = self._generate_pie_chart(priority_counts_friendly, 'Work Orders by Priority')
+        chart_sla = self._generate_pie_chart(sla_status_counts_friendly, 'SLA Compliance')
+        
+        # Convert top assets/rooms/parts to dict for bar charts
+        top_assets_dict = dict(top_assets) if top_assets else {}
+        top_rooms_dict = dict(top_rooms) if top_rooms else {}
+        top_parts_dict = dict(top_parts) if top_parts else {}
+        
+        chart_assets = self._generate_bar_chart(top_assets_dict, 'Top 5 Assets', 'Asset', 'Work Orders')
+        chart_rooms = self._generate_bar_chart(top_rooms_dict, 'Top 5 Rooms', 'Room', 'Work Orders')
+        chart_parts = self._generate_bar_chart(top_parts_dict, 'Top 5 Parts Used', 'Part', 'Quantity')
+        chart_days = self._generate_line_chart(dict(day_counts), 'Work Orders by Day', 'Day of Month', 'Number of Work Orders')
+        
+        # Generate wordcloud chart (simplified as bar chart for now)
+        top_issues_dict = dict(top_issues) if top_issues else {}
+        chart_wordcloud = self._generate_bar_chart(top_issues_dict, 'Most Frequent Issues', 'Word', 'Count')
+
         # Pass all data to QWeb
         data = {
             'building': self.building_id.name,
@@ -117,5 +203,15 @@ class MonthlyBuildingReportWizard(models.TransientModel):
             'sla_status_counts': sla_status_counts_friendly,
             'day_counts': dict(day_counts),
             'generated_on': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            # Chart images
+            'chart_status': chart_status,
+            'chart_type': chart_type,
+            'chart_priority': chart_priority,
+            'chart_sla': chart_sla,
+            'chart_assets': chart_assets,
+            'chart_rooms': chart_rooms,
+            'chart_parts': chart_parts,
+            'chart_days': chart_days,
+            'chart_wordcloud': chart_wordcloud,
         }
         return self.env.ref('facilities_management.monthly_building_report_pdf_action').report_action(self, data={'doc': data})


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add chart generation to the monthly building report wizard to resolve `KeyError: 'chart_status'` in the PDF report.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `KeyError: 'chart_status'` occurred because the QWeb template expected base64-encoded chart images, but the wizard was only providing raw data. This PR integrates matplotlib to generate and pass these charts to the report, along with conditional rendering in the template for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-a996e31b-1c80-4328-8073-ee039328d49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a996e31b-1c80-4328-8073-ee039328d49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>