### PR TITLE
Fix missing critical threshold attribute in sla

### DIFF
--- a/test_sla_fields.py
+++ b/test_sla_fields.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+
+# Add the Odoo path
+sys.path.insert(0, '/workspace/odoo17')
+
+def test_sla_fields():
+    """Test to verify SLA field names"""
+    
+    # Test the workorder_sla_integration.py file
+    integration_file = "/workspace/odoo17/addons/facilities_management/models/workorder_sla_integration.py"
+    
+    print("Testing workorder_sla_integration.py file...")
+    
+    with open(integration_file, 'r') as f:
+        lines = f.readlines()
+    
+    for i, line in enumerate(lines, 1):
+        if 'critical_threshold' in line and 'sla_id' in line:
+            print(f"Line {i}: {line.strip()}")
+            if 'critical_threshold_hours' in line:
+                print("✓ Using correct field name: critical_threshold_hours")
+            elif 'critical_threshold' in line and 'critical_threshold_hours' not in line:
+                print("✗ Using incorrect field name: critical_threshold")
+    
+    print("\nTesting facilities.sla model fields...")
+    
+    # Test the facilities.sla model
+    sla_file = "/workspace/odoo17/addons/facilities_management/models/sla.py"
+    
+    with open(sla_file, 'r') as f:
+        lines = f.readlines()
+    
+    critical_threshold_hours_found = False
+    warning_threshold_hours_found = False
+    
+    for i, line in enumerate(lines, 1):
+        if 'critical_threshold_hours' in line:
+            critical_threshold_hours_found = True
+            print(f"Line {i}: Found critical_threshold_hours")
+        if 'warning_threshold_hours' in line:
+            warning_threshold_hours_found = True
+            print(f"Line {i}: Found warning_threshold_hours")
+    
+    if critical_threshold_hours_found:
+        print("✓ critical_threshold_hours field exists in facilities.sla")
+    else:
+        print("✗ critical_threshold_hours field missing in facilities.sla")
+    
+    if warning_threshold_hours_found:
+        print("✓ warning_threshold_hours field exists in facilities.sla")
+    else:
+        print("✗ warning_threshold_hours field missing in facilities.sla")
+
+if __name__ == "__main__":
+    test_sla_fields()


### PR DESCRIPTION
Add a diagnostic script to verify SLA threshold field names in `facilities.sla` and related integration code.

This script was created to debug a persistent `AttributeError` that suggested a missing `critical_threshold` field, even though the code correctly uses `critical_threshold_hours`. It helps confirm the current state of the code and rule out direct coding errors, pointing towards potential caching issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3fd7383-2b1e-4a0d-bcfe-d808819e2658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3fd7383-2b1e-4a0d-bcfe-d808819e2658">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>