### PR TITLE
Fix xml tag mismatch in esg reporting

### DIFF
--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -521,6 +521,7 @@
                                 <p><strong>Include Risk Analysis:</strong> <t t-esc="'Yes' if o and o.include_risk_analysis else 'No'"/></p>
                                 <p><strong>Include Trends:</strong> <t t-esc="'Yes' if o and o.include_trends else 'No'"/></p>
                                 <p><strong>Include Forecasting:</strong> <t t-esc="'Yes' if o and o.include_forecasting else 'No'"/></p>
+                                </t>
                             </t>
                             <t t-else="">
                                 <div class="alert alert-warning" role="alert">


### PR DESCRIPTION
Fix XML syntax error in `esg_report_templates.xml` by adding a missing closing `</t>` tag.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ddc40b7-a9cd-4609-a992-10089421c64b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ddc40b7-a9cd-4609-a992-10089421c64b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>