### PR TITLE
Fix qweb template syntax error

### DIFF
--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -382,167 +382,167 @@
                                 </div>
                                 
                                 <t t-if="report_data and isinstance(report_data, dict) and report_data.get('report_info')">
-                                <t t-set="report_info" t-value="report_data.get('report_info')"/>
-                                
-                                <t t-if="report_info.get('note')">
-                                    <div class="alert alert-warning" role="alert">
-                                        <strong>Note:</strong> <t t-esc="report_info.get('note')"/>
-                                    </div>
-                                </t>
-                                
-                                <h3>Executive Summary</h3>
-                                <p>This enhanced ESG report provides comprehensive analysis of environmental, social, and governance performance with advanced analytics and insights.</p>
-                                <p><strong>Total Assets Analyzed:</strong> <t t-esc="report_info.get('total_assets', 0)"/></p>
-                                <p><strong>Report Theme:</strong> <t t-esc="report_info.get('theme', 'Default')"/></p>
-                                
-                                <!-- Environmental Metrics -->
-                                <t t-if="o.include_section_environmental and report_data and isinstance(report_data, dict) and report_data.get('environmental_metrics')">
-                                    <h3>Environmental Performance</h3>
-                                    <t t-set="env_metrics" t-value="report_data.get('environmental_metrics')"/>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <h4>Key Metrics</h4>
-                                            <ul>
-                                                <li><strong>Total Carbon Footprint:</strong> <t t-esc="env_metrics.get('total_carbon_footprint', 0)"/> kg CO2</li>
-                                                <li><strong>Energy Efficiency Score:</strong> <t t-esc="env_metrics.get('energy_efficiency_score', 0)"/>%</li>
-                                                <li><strong>Renewable Energy Usage:</strong> <t t-esc="env_metrics.get('renewable_energy_usage', 0)"/>%</li>
-                                                <li><strong>Waste Management Score:</strong> <t t-esc="env_metrics.get('waste_management_score', 0)"/>%</li>
-                                                <li><strong>Water Consumption:</strong> <t t-esc="env_metrics.get('water_consumption', 0)"/> liters</li>
-                                                <li><strong>Biodiversity Impact:</strong> <t t-esc="env_metrics.get('biodiversity_impact', 0)"/>/10</li>
-                                            </ul>
+                                    <t t-set="report_info" t-value="report_data.get('report_info')"/>
+                                    
+                                    <t t-if="report_info.get('note')">
+                                        <div class="alert alert-warning" role="alert">
+                                            <strong>Note:</strong> <t t-esc="report_info.get('note')"/>
                                         </div>
-                                        <div class="col-md-6">
-                                            <h4>Analysis</h4>
-                                            <p>Environmental performance analysis based on carbon footprint, energy efficiency, and sustainability metrics.</p>
+                                    </t>
+                                    
+                                    <h3>Executive Summary</h3>
+                                    <p>This enhanced ESG report provides comprehensive analysis of environmental, social, and governance performance with advanced analytics and insights.</p>
+                                    <p><strong>Total Assets Analyzed:</strong> <t t-esc="report_info.get('total_assets', 0)"/></p>
+                                    <p><strong>Report Theme:</strong> <t t-esc="report_info.get('theme', 'Default')"/></p>
+                                    
+                                    <!-- Environmental Metrics -->
+                                    <t t-if="o.include_section_environmental and report_data and isinstance(report_data, dict) and report_data.get('environmental_metrics')">
+                                        <h3>Environmental Performance</h3>
+                                        <t t-set="env_metrics" t-value="report_data.get('environmental_metrics')"/>
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <h4>Key Metrics</h4>
+                                                <ul>
+                                                    <li><strong>Total Carbon Footprint:</strong> <t t-esc="env_metrics.get('total_carbon_footprint', 0)"/> kg CO2</li>
+                                                    <li><strong>Energy Efficiency Score:</strong> <t t-esc="env_metrics.get('energy_efficiency_score', 0)"/>%</li>
+                                                    <li><strong>Renewable Energy Usage:</strong> <t t-esc="env_metrics.get('renewable_energy_usage', 0)"/>%</li>
+                                                    <li><strong>Waste Management Score:</strong> <t t-esc="env_metrics.get('waste_management_score', 0)"/>%</li>
+                                                    <li><strong>Water Consumption:</strong> <t t-esc="env_metrics.get('water_consumption', 0)"/> liters</li>
+                                                    <li><strong>Biodiversity Impact:</strong> <t t-esc="env_metrics.get('biodiversity_impact', 0)"/>/10</li>
+                                                </ul>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <h4>Analysis</h4>
+                                                <p>Environmental performance analysis based on carbon footprint, energy efficiency, and sustainability metrics.</p>
+                                            </div>
                                         </div>
-                                    </div>
-                                </t>
-                                
-                                <!-- Social Metrics -->
-                                <t t-if="o.include_section_social and report_data and isinstance(report_data, dict) and report_data.get('social_metrics')">
-                                    <h3>Social Performance</h3>
-                                    <t t-set="social_metrics" t-value="report_data.get('social_metrics')"/>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <h4>Key Metrics</h4>
-                                            <ul>
-                                                <li><strong>Community Impact Score:</strong> <t t-esc="social_metrics.get('community_impact_score', 0)"/>/10</li>
-                                                <li><strong>Employee Satisfaction:</strong> <t t-esc="social_metrics.get('employee_satisfaction', 0)"/>/10</li>
-                                                <li><strong>Diversity Index:</strong> <t t-esc="social_metrics.get('diversity_index', 0)"/></li>
-                                                <li><strong>Health &amp; Safety Score:</strong> <t t-esc="social_metrics.get('health_safety_score', 0)"/>/10</li>
-                                                <li><strong>Training Hours:</strong> <t t-esc="social_metrics.get('training_hours', 0)"/> hours</li>
-                                                <li><strong>Local Procurement:</strong> <t t-esc="social_metrics.get('local_procurement', 0)"/>%</li>
-                                            </ul>
+                                    </t>
+                                    
+                                    <!-- Social Metrics -->
+                                    <t t-if="o.include_section_social and report_data and isinstance(report_data, dict) and report_data.get('social_metrics')">
+                                        <h3>Social Performance</h3>
+                                        <t t-set="social_metrics" t-value="report_data.get('social_metrics')"/>
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <h4>Key Metrics</h4>
+                                                <ul>
+                                                    <li><strong>Community Impact Score:</strong> <t t-esc="social_metrics.get('community_impact_score', 0)"/>/10</li>
+                                                    <li><strong>Employee Satisfaction:</strong> <t t-esc="social_metrics.get('employee_satisfaction', 0)"/>/10</li>
+                                                    <li><strong>Diversity Index:</strong> <t t-esc="social_metrics.get('diversity_index', 0)"/></li>
+                                                    <li><strong>Health &amp; Safety Score:</strong> <t t-esc="social_metrics.get('health_safety_score', 0)"/>/10</li>
+                                                    <li><strong>Training Hours:</strong> <t t-esc="social_metrics.get('training_hours', 0)"/> hours</li>
+                                                    <li><strong>Local Procurement:</strong> <t t-esc="social_metrics.get('local_procurement', 0)"/>%</li>
+                                                </ul>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <h4>Analysis</h4>
+                                                <p>Social responsibility metrics and community impact analysis.</p>
+                                            </div>
                                         </div>
-                                        <div class="col-md-6">
-                                            <h4>Analysis</h4>
-                                            <p>Social responsibility metrics and community impact analysis.</p>
+                                    </t>
+                                    
+                                    <!-- Governance Metrics -->
+                                    <t t-if="o.include_section_governance and report_data and isinstance(report_data, dict) and report_data.get('governance_metrics')">
+                                        <h3>Governance Performance</h3>
+                                        <t t-set="gov_metrics" t-value="report_data.get('governance_metrics')"/>
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <h4>Key Metrics</h4>
+                                                <ul>
+                                                    <li><strong>Compliance Rate:</strong> <t t-esc="gov_metrics.get('compliance_rate', 0)"/>%</li>
+                                                    <li><strong>Risk Management Score:</strong> <t t-esc="gov_metrics.get('risk_management_score', 0)"/>/10</li>
+                                                    <li><strong>Transparency Index:</strong> <t t-esc="gov_metrics.get('transparency_index', 0)"/>/10</li>
+                                                    <li><strong>Board Diversity:</strong> <t t-esc="gov_metrics.get('board_diversity', 0)"/></li>
+                                                    <li><strong>Ethics Score:</strong> <t t-esc="gov_metrics.get('ethics_score', 0)"/>/10</li>
+                                                    <li><strong>Stakeholder Engagement:</strong> <t t-esc="gov_metrics.get('stakeholder_engagement', 0)"/>/10</li>
+                                                </ul>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <h4>Analysis</h4>
+                                                <p>Governance and compliance metrics with risk management analysis.</p>
+                                            </div>
                                         </div>
-                                    </div>
-                                </t>
-                                
-                                <!-- Governance Metrics -->
-                                <t t-if="o.include_section_governance and report_data and isinstance(report_data, dict) and report_data.get('governance_metrics')">
-                                    <h3>Governance Performance</h3>
-                                    <t t-set="gov_metrics" t-value="report_data.get('governance_metrics')"/>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <h4>Key Metrics</h4>
-                                            <ul>
-                                                <li><strong>Compliance Rate:</strong> <t t-esc="gov_metrics.get('compliance_rate', 0)"/>%</li>
-                                                <li><strong>Risk Management Score:</strong> <t t-esc="gov_metrics.get('risk_management_score', 0)"/>/10</li>
-                                                <li><strong>Transparency Index:</strong> <t t-esc="gov_metrics.get('transparency_index', 0)"/>/10</li>
-                                                <li><strong>Board Diversity:</strong> <t t-esc="gov_metrics.get('board_diversity', 0)"/></li>
-                                                <li><strong>Ethics Score:</strong> <t t-esc="gov_metrics.get('ethics_score', 0)"/>/10</li>
-                                                <li><strong>Stakeholder Engagement:</strong> <t t-esc="gov_metrics.get('stakeholder_engagement', 0)"/>/10</li>
-                                            </ul>
+                                    </t>
+                                    
+                                    <!-- Analytics -->
+                                    <t t-if="o.include_section_analytics and report_data and isinstance(report_data, dict) and report_data.get('analytics')">
+                                        <h3>Advanced Analytics</h3>
+                                        <t t-set="analytics_data" t-value="report_data.get('analytics')"/>
+                                        <div class="row">
+                                            <div class="col-md-6">
+                                                <h4>Performance Trends</h4>
+                                                <ul>
+                                                    <li><strong>Trend Direction:</strong> <t t-esc="analytics_data.get('performance_trends', {}).get('trend', 'N/A')"/></li>
+                                                    <li><strong>Improvement Rate:</strong> <t t-esc="analytics_data.get('performance_trends', {}).get('rate', 0)"/>%</li>
+                                                </ul>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <h4>Predictive Insights</h4>
+                                                <ul>
+                                                    <li><strong>Prediction:</strong> <t t-esc="analytics_data.get('predictive_insights', {}).get('prediction', 'N/A')"/></li>
+                                                    <li><strong>Confidence:</strong> <t t-esc="analytics_data.get('predictive_insights', {}).get('confidence', 0)"/></li>
+                                                </ul>
+                                            </div>
                                         </div>
-                                        <div class="col-md-6">
-                                            <h4>Analysis</h4>
-                                            <p>Governance and compliance metrics with risk management analysis.</p>
-                                        </div>
-                                    </div>
-                                </t>
-                                
-                                <!-- Analytics -->
-                                <t t-if="o.include_section_analytics and report_data and isinstance(report_data, dict) and report_data.get('analytics')">
-                                    <h3>Advanced Analytics</h3>
-                                    <t t-set="analytics_data" t-value="report_data.get('analytics')"/>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <h4>Performance Trends</h4>
-                                            <ul>
-                                                <li><strong>Trend Direction:</strong> <t t-esc="analytics_data.get('performance_trends', {}).get('trend', 'N/A')"/></li>
-                                                <li><strong>Improvement Rate:</strong> <t t-esc="analytics_data.get('performance_trends', {}).get('rate', 0)"/>%</li>
-                                            </ul>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <h4>Predictive Insights</h4>
-                                            <ul>
-                                                <li><strong>Prediction:</strong> <t t-esc="analytics_data.get('predictive_insights', {}).get('prediction', 'N/A')"/></li>
-                                                <li><strong>Confidence:</strong> <t t-esc="analytics_data.get('predictive_insights', {}).get('confidence', 0)"/></li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </t>
-                                
-                                <!-- Recommendations -->
-                                <t t-if="o.include_section_recommendations and report_data and isinstance(report_data, dict) and report_data.get('recommendations')">
-                                    <h3>Recommendations</h3>
-                                    <t t-set="recommendations" t-value="report_data.get('recommendations')"/>
-                                    <p>Strategic recommendations based on ESG performance analysis:</p>
-                                    <ul>
-                                        <t t-foreach="recommendations" t-as="rec">
-                                            <li><strong><t t-esc="rec.get('category', 'General')"/>:</strong> <t t-esc="rec.get('recommendation', '')"/></li>
-                                        </t>
-                                    </ul>
-                                </t>
-                                
-                                <!-- Thresholds -->
-                                <t t-if="o.include_thresholds and report_data and isinstance(report_data, dict) and report_data.get('thresholds')">
-                                    <h3>Performance Thresholds</h3>
-                                    <t t-set="thresholds" t-value="report_data.get('thresholds')"/>
-                                    <div class="alert alert-info" role="alert">
-                                        <h4>Threshold Status</h4>
+                                    </t>
+                                    
+                                    <!-- Recommendations -->
+                                    <t t-if="o.include_section_recommendations and report_data and isinstance(report_data, dict) and report_data.get('recommendations')">
+                                        <h3>Recommendations</h3>
+                                        <t t-set="recommendations" t-value="report_data.get('recommendations')"/>
+                                        <p>Strategic recommendations based on ESG performance analysis:</p>
                                         <ul>
-                                            <li><strong>Carbon Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('carbon_threshold_exceeded') else 'Within Limits'"/></li>
-                                            <li><strong>Compliance Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('compliance_threshold_exceeded') else 'Within Limits'"/></li>
-                                            <li><strong>Social Impact Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('social_impact_threshold_exceeded') else 'Within Limits'"/></li>
+                                            <t t-foreach="recommendations" t-as="rec">
+                                                <li><strong><t t-esc="rec.get('category', 'General')"/>:</strong> <t t-esc="rec.get('recommendation', '')"/></li>
+                                            </t>
                                         </ul>
-                                    </div>
+                                    </t>
+                                    
+                                    <!-- Thresholds -->
+                                    <t t-if="o.include_thresholds and report_data and isinstance(report_data, dict) and report_data.get('thresholds')">
+                                        <h3>Performance Thresholds</h3>
+                                        <t t-set="thresholds" t-value="report_data.get('thresholds')"/>
+                                        <div class="alert alert-info" role="alert">
+                                            <h4>Threshold Status</h4>
+                                            <ul>
+                                                <li><strong>Carbon Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('carbon_threshold_exceeded') else 'Within Limits'"/></li>
+                                                <li><strong>Compliance Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('compliance_threshold_exceeded') else 'Within Limits'"/></li>
+                                                <li><strong>Social Impact Threshold:</strong> <t t-esc="'Exceeded' if thresholds.get('social_impact_threshold_exceeded') else 'Within Limits'"/></li>
+                                            </ul>
+                                        </div>
+                                    </t>
+                                    
+                                    <h3>Report Configuration</h3>
+                                    <p><strong>Theme:</strong> <t t-esc="o.report_theme or 'Default'"/></p>
+                                    <p><strong>Include Charts:</strong> <t t-esc="'Yes' if o and o.include_charts else 'No'"/></p>
+                                    <p><strong>Include Executive Summary:</strong> <t t-esc="'Yes' if o and o.include_executive_summary else 'No'"/></p>
+                                    <p><strong>Include Recommendations:</strong> <t t-esc="'Yes' if o and o.include_recommendations else 'No'"/></p>
+                                    <p><strong>Include Benchmarks:</strong> <t t-esc="'Yes' if o and o.include_benchmarks else 'No'"/></p>
+                                    <p><strong>Include Risk Analysis:</strong> <t t-esc="'Yes' if o and o.include_risk_analysis else 'No'"/></p>
+                                    <p><strong>Include Trends:</strong> <t t-esc="'Yes' if o and o.include_trends else 'No'"/></p>
+                                    <p><strong>Include Forecasting:</strong> <t t-esc="'Yes' if o and o.include_forecasting else 'No'"/></p>
                                 </t>
-                                
-                                <h3>Report Configuration</h3>
-                                <p><strong>Theme:</strong> <t t-esc="o.report_theme or 'Default'"/></p>
-                                <p><strong>Include Charts:</strong> <t t-esc="'Yes' if o and o.include_charts else 'No'"/></p>
-                                <p><strong>Include Executive Summary:</strong> <t t-esc="'Yes' if o and o.include_executive_summary else 'No'"/></p>
-                                <p><strong>Include Recommendations:</strong> <t t-esc="'Yes' if o and o.include_recommendations else 'No'"/></p>
-                                <p><strong>Include Benchmarks:</strong> <t t-esc="'Yes' if o and o.include_benchmarks else 'No'"/></p>
-                                <p><strong>Include Risk Analysis:</strong> <t t-esc="'Yes' if o and o.include_risk_analysis else 'No'"/></p>
-                                <p><strong>Include Trends:</strong> <t t-esc="'Yes' if o and o.include_trends else 'No'"/></p>
-                                <p><strong>Include Forecasting:</strong> <t t-esc="'Yes' if o and o.include_forecasting else 'No'"/></p>
+                                <t t-else="">
+                                    <div class="alert alert-warning" role="alert">
+                                        <h4>No Report Data Available</h4>
+                                        <p>The report data could not be generated. This might be due to:</p>
+                                        <ul>
+                                            <li>No wizard object available for report generation</li>
+                                            <li>No assets found matching the specified criteria</li>
+                                            <li>Data processing error</li>
+                                            <li>Configuration issues</li>
+                                        </ul>
+                                        <p>Please check your report settings and try again.</p>
+                                    </div>
                                 </t>
                             </t>
                             <t t-else="">
                                 <div class="alert alert-warning" role="alert">
-                                    <h4>No Report Data Available</h4>
-                                    <p>The report data could not be generated. This might be due to:</p>
-                                    <ul>
-                                        <li>No wizard object available for report generation</li>
-                                        <li>No assets found matching the specified criteria</li>
-                                        <li>Data processing error</li>
-                                        <li>Configuration issues</li>
-                                    </ul>
-                                    <p>Please check your report settings and try again.</p>
+                                    <h4>No Data Available</h4>
+                                    <p>The ESG report wizard object is not available or has no valid ID.</p>
+                                    <p><strong>Wizard object exists:</strong> No</p>
                                 </div>
                             </t>
-                        <t t-else="">
-                            <div class="alert alert-warning" role="alert">
-                                <h4>No Data Available</h4>
-                                <p>The ESG report wizard object is not available or has no valid ID.</p>
-                                <p><strong>Wizard object exists:</strong> No</p>
-                            </div>
-                        </t>
                             
                             <p><strong>Generated at:</strong> <t t-esc="context_timestamp(datetime.datetime.now())"/></p>
                         </div>

--- a/simple_validation.py
+++ b/simple_validation.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+def check_qweb_structure(file_path):
+    """Check QWeb template structure for the specific issue we fixed."""
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        
+        # Check for the specific pattern that was causing the issue
+        # Look for t-else="" that might not be properly structured
+        lines = content.split('\n')
+        issues = []
+        
+        for i, line in enumerate(lines, 1):
+            # Check for t-else="" without proper t-if structure
+            if 't-else=""' in line:
+                # Look for t-if before this line in the same context
+                found_t_if = False
+                for j in range(i-1, max(0, i-50), -1):  # Look back up to 50 lines
+                    if 't-if=' in lines[j]:
+                        found_t_if = True
+                        break
+                    elif 't-elif=' in lines[j]:
+                        found_t_if = True
+                        break
+                    elif 't-else=""' in lines[j] and j != i:
+                        # Found another t-else, which is fine
+                        break
+                    elif '</t>' in lines[j]:
+                        # Check if this closes a t-if block
+                        # Look for the opening t-if
+                        for k in range(j-1, max(0, j-20), -1):
+                            if 't-if=' in lines[k]:
+                                found_t_if = True
+                                break
+                            elif 't-elif=' in lines[k]:
+                                found_t_if = True
+                                break
+                            elif '<t ' in lines[k] and 't-else=""' not in lines[k]:
+                                # Found another t element, stop looking
+                                break
+                        if found_t_if:
+                            break
+                
+                if not found_t_if:
+                    issues.append(f"Line {i}: t-else directive without preceding t-if or t-elif")
+        
+        if issues:
+            print(f"✗ {file_path} - Found {len(issues)} QWeb structure issues:")
+            for issue in issues:
+                print(f"  - {issue}")
+            return False
+        else:
+            print(f"✓ {file_path} - QWeb structure is valid")
+            return True
+            
+    except Exception as e:
+        print(f"✗ {file_path} - Error: {e}")
+        return False
+
+def main():
+    # Check the ESG report templates file
+    esg_template_file = "odoo17/addons/esg_reporting/report/esg_report_templates.xml"
+    
+    print("Validating QWeb Template Structure...")
+    success = check_qweb_structure(esg_template_file)
+    
+    if success:
+        print("\n✓ All QWeb templates have valid structure!")
+        return 0
+    else:
+        print("\n✗ QWeb structure validation failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validate_qweb.py
+++ b/validate_qweb.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+import xml.etree.ElementTree as ET
+import re
+import sys
+
+def check_qweb_structure(file_path):
+    """Check QWeb template structure for common issues."""
+    try:
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+        
+        issues = []
+        
+        # Check for t-if, t-else, t-elif directives
+        for elem in root.iter():
+            # Check for t-else without proper t-if structure
+            if 't-else' in elem.attrib:
+                # Check if this element has a proper t-if sibling
+                parent = elem
+                while parent is not None:
+                    parent = parent.getparent()
+                    if parent is not None:
+                        siblings = list(parent)
+                        current_index = siblings.index(elem)
+                        
+                        # Look for t-if before this t-else
+                        found_t_if = False
+                        for i in range(current_index - 1, -1, -1):
+                            if 't-if' in siblings[i].attrib:
+                                found_t_if = True
+                                break
+                            elif 't-elif' in siblings[i].attrib:
+                                found_t_if = True
+                                break
+                            elif 't-else' in siblings[i].attrib:
+                                # Found another t-else, which is fine
+                                break
+                        
+                        if not found_t_if:
+                            issues.append(f"t-else directive without preceding t-if or t-elif")
+                        break
+            
+            # Check for t-elif without proper t-if structure
+            if 't-elif' in elem.attrib:
+                parent = elem
+                while parent is not None:
+                    parent = parent.getparent()
+                    if parent is not None:
+                        siblings = list(parent)
+                        current_index = siblings.index(elem)
+                        
+                        # Look for t-if or t-elif before this t-elif
+                        found_t_if = False
+                        for i in range(current_index - 1, -1, -1):
+                            if 't-if' in siblings[i].attrib:
+                                found_t_if = True
+                                break
+                            elif 't-elif' in siblings[i].attrib:
+                                found_t_if = True
+                                break
+                            elif 't-else' in siblings[i].attrib:
+                                # Found t-else, which means no t-if before
+                                break
+                        
+                        if not found_t_if:
+                            issues.append(f"t-elif directive without preceding t-if or t-elif")
+                        break
+        
+        if issues:
+            print(f"✗ {file_path} - Found {len(issues)} QWeb structure issues:")
+            for issue in issues:
+                print(f"  - {issue}")
+            return False
+        else:
+            print(f"✓ {file_path} - QWeb structure is valid")
+            return True
+            
+    except Exception as e:
+        print(f"✗ {file_path} - Error: {e}")
+        return False
+
+def main():
+    # Check the ESG report templates file
+    esg_template_file = "odoo17/addons/esg_reporting/report/esg_report_templates.xml"
+    
+    print("Validating QWeb Template Structure...")
+    success = check_qweb_structure(esg_template_file)
+    
+    if success:
+        print("\n✓ All QWeb templates have valid structure!")
+        return 0
+    else:
+        print("\n✗ QWeb structure validation failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validate_xml.py
+++ b/validate_xml.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+import xml.etree.ElementTree as ET
+import sys
+
+def validate_xml_file(file_path):
+    """Validate XML syntax of a file."""
+    try:
+        tree = ET.parse(file_path)
+        print(f"✓ {file_path} - XML syntax is valid")
+        return True
+    except ET.ParseError as e:
+        print(f"✗ {file_path} - XML syntax error: {e}")
+        return False
+    except Exception as e:
+        print(f"✗ {file_path} - Error: {e}")
+        return False
+
+def main():
+    # Validate the ESG report templates file
+    esg_template_file = "odoo17/addons/esg_reporting/report/esg_report_templates.xml"
+    
+    print("Validating ESG Report Templates XML...")
+    success = validate_xml_file(esg_template_file)
+    
+    if success:
+        print("\n✓ All XML files are syntactically valid!")
+        return 0
+    else:
+        print("\n✗ XML validation failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes QWeb template syntax error in ESG reports to resolve `t-else` directive issue.

The `odoo.addons.base.models.ir_qweb.QWebException: SyntaxError: t-elif directive must be preceded by t-if or t-elif directive` occurred because a nested `t-if` block in `esg_reporting.report_enhanced_esg_wizard_document` was not properly closed before a subsequent `t-else` directive. This prevented the generation and download of ESG reports. The fix ensures correct nesting of conditional QWeb directives.

---
<a href="https://cursor.com/background-agent?bcId=bc-04d2644d-4759-4f00-a0e5-02cc3046a845">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04d2644d-4759-4f00-a0e5-02cc3046a845">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>