### PR TITLE
Debug qweb template rendering error

### DIFF
--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -368,18 +368,40 @@
                                 
                                 <!-- Access report data from the wizard object with robust error handling -->
                                 <t t-set="report_data" t-value="{}"/>
-                                <t t-if="o and hasattr(o, '_compute_safe_report_data_manual')">
-                                    <t t-set="method" t-value="getattr(o, '_compute_safe_report_data_manual', None)"/>
-                                    <t t-if="method and callable(method)">
-                                        <t t-set="report_data" t-value="method()"/>
+                                <t t-if="o and o.id">
+                                    <t t-if="hasattr(o, '_compute_safe_report_data_manual')">
+                                        <t t-set="method" t-value="getattr(o, '_compute_safe_report_data_manual', None)"/>
+                                        <t t-if="method is not None and callable(method)">
+                                            <t t-try="">
+                                                <t t-set="report_data" t-value="method()"/>
+                                            </t>
+                                            <t t-catch="">
+                                                <t t-set="report_data" t-value="{}"/>
+                                            </t>
+                                        </t>
+                                        <t t-else="">
+                                            <t t-set="report_data" t-value="{}"/>
+                                        </t>
                                     </t>
+                                    <t t-else="">
+                                        <t t-set="report_data" t-value="{}"/>
+                                    </t>
+                                </t>
+                                <t t-else="">
+                                    <t t-set="report_data" t-value="{}"/>
+                                </t>
+                                
+                                <!-- Fallback: If report_data is still empty, create a basic structure -->
+                                <t t-if="not report_data or not isinstance(report_data, dict)">
+                                    <t t-set="report_data" t-value="{}"/>
                                 </t>
                                 
                                 <!-- Debug information -->
                                 <div class="alert alert-info" role="alert">
                                     <h4>Debug Information</h4>
-                                    <p><strong>Wizard object exists:</strong> Yes</p>
+                                    <p><strong>Wizard object exists:</strong> <t t-esc="'Yes' if o and o.id else 'No'"/></p>
                                     <p><strong>Wizard safe_report_data method exists:</strong> <t t-esc="'Yes' if o and hasattr(o, '_compute_safe_report_data_manual') else 'No'"/></p>
+                                    <p><strong>Method is callable:</strong> <t t-esc="'Yes' if o and hasattr(o, '_compute_safe_report_data_manual') and callable(getattr(o, '_compute_safe_report_data_manual', None)) else 'No'"/></p>
                                     <p><strong>Report data exists:</strong> <t t-esc="'Yes' if report_data else 'No'"/></p>
                                     <p><strong>Report data type:</strong> <t t-esc="'dict' if report_data and isinstance(report_data, dict) else 'list' if report_data and isinstance(report_data, list) else 'str' if report_data and isinstance(report_data, str) else 'int' if report_data and isinstance(report_data, int) else 'float' if report_data and isinstance(report_data, float) else 'bool' if report_data and isinstance(report_data, bool) else 'None' if report_data is None else 'other'"/></p>
                                     <p><strong>Report data keys:</strong> <t t-esc="'Available' if report_data and isinstance(report_data, dict) and len(report_data) > 0 else 'No keys available'"/></p>
@@ -389,8 +411,12 @@
                                 
                                 <t t-if="report_data and isinstance(report_data, dict) and report_data.get('report_info')">
                                     <t t-set="report_info" t-value="report_data.get('report_info')"/>
+                                </t>
+                                <t t-else="">
+                                    <t t-set="report_info" t-value="{}"/>
+                                </t>
                                     
-                                    <t t-if="report_info.get('note')">
+                                    <t t-if="report_info and report_info.get('note')">
                                         <div class="alert alert-warning" role="alert">
                                             <strong>Note:</strong> <t t-esc="report_info.get('note')"/>
                                         </div>
@@ -398,11 +424,11 @@
                                     
                                     <h3>Executive Summary</h3>
                                     <p>This enhanced ESG report provides comprehensive analysis of environmental, social, and governance performance with advanced analytics and insights.</p>
-                                    <p><strong>Total Assets Analyzed:</strong> <t t-esc="report_info.get('total_assets', 0)"/></p>
-                                    <p><strong>Report Theme:</strong> <t t-esc="report_info.get('theme', 'Default')"/></p>
+                                    <p><strong>Total Assets Analyzed:</strong> <t t-esc="report_info.get('total_assets', 0) if report_info else 0"/></p>
+                                    <p><strong>Report Theme:</strong> <t t-esc="report_info.get('theme', 'Default') if report_info else 'Default'"/></p>
                                     
                                     <!-- Environmental Metrics -->
-                                    <t t-if="o.include_section_environmental and report_data and isinstance(report_data, dict) and report_data.get('environmental_metrics')">
+                                    <t t-if="o and o.include_section_environmental and report_data and isinstance(report_data, dict) and report_data.get('environmental_metrics')">
                                         <h3>Environmental Performance</h3>
                                         <t t-set="env_metrics" t-value="report_data.get('environmental_metrics')"/>
                                         <div class="row">

--- a/odoo17/addons/esg_reporting/wizard/esg_report_wizard.py
+++ b/odoo17/addons/esg_reporting/wizard/esg_report_wizard.py
@@ -203,43 +203,82 @@ class EnhancedESGWizard(models.TransientModel):
     def _compute_safe_report_data_manual(self):
         """Manual computation of safe_report_data for template access"""
         try:
+            # Ensure self is a valid record
+            if not self or not hasattr(self, 'id') or not self.id:
+                return self._get_default_report_data()
+            
             if hasattr(self, 'report_data') and self.report_data and isinstance(self.report_data, dict):
                 return self.report_data
             else:
                 # Return a default structure if no data is available
-                return {
-                    'report_info': {
-                        'name': getattr(self, 'report_name', 'ESG Report'),
-                        'type': getattr(self, 'report_type', 'sustainability'),
-                        'date_from': getattr(self, 'date_from', None),
-                        'date_to': getattr(self, 'date_to', None),
-                        'company': getattr(self, 'company_name', 'YourCompany'),
-                        'generated_at': fields.Datetime.now().isoformat(),
-                        'total_assets': 0,
-                        'granularity': getattr(self, 'granularity', 'monthly'),
-                        'theme': getattr(self, 'report_theme', 'default'),
-                        'note': 'Report data not available. Please regenerate the report.'
-                    },
-                    'environmental_metrics': {},
-                    'social_metrics': {},
-                    'governance_metrics': {},
-                    'analytics': {},
-                    'trends': {},
-                    'benchmarks': {},
-                    'risk_analysis': {},
-                    'predictions': {},
-                    'recommendations': [
-                        {'category': 'data', 'recommendation': 'Report data not available. Please regenerate the report.'}
-                    ],
-                    'thresholds': {},
-                    'custom_metrics': {},
-                    'comparison_data': {}
-                }
+                return self._get_default_report_data()
         except Exception as e:
             # Log the error for debugging
             _logger = logging.getLogger(__name__)
             _logger.error(f"Error in _compute_safe_report_data_manual: {str(e)}")
-            return {}
+            return self._get_default_report_data()
+    
+    def _get_default_report_data(self):
+        """Get default report data structure"""
+        try:
+            return {
+                'report_info': {
+                    'name': getattr(self, 'report_name', 'ESG Report') if hasattr(self, 'report_name') else 'ESG Report',
+                    'type': getattr(self, 'report_type', 'sustainability') if hasattr(self, 'report_type') else 'sustainability',
+                    'date_from': getattr(self, 'date_from', None) if hasattr(self, 'date_from') else None,
+                    'date_to': getattr(self, 'date_to', None) if hasattr(self, 'date_to') else None,
+                    'company': getattr(self, 'company_name', 'YourCompany') if hasattr(self, 'company_name') else 'YourCompany',
+                    'generated_at': fields.Datetime.now().isoformat(),
+                    'total_assets': 0,
+                    'granularity': getattr(self, 'granularity', 'monthly') if hasattr(self, 'granularity') else 'monthly',
+                    'theme': getattr(self, 'report_theme', 'default') if hasattr(self, 'report_theme') else 'default',
+                    'note': 'Report data not available. Please regenerate the report.'
+                },
+                'environmental_metrics': {},
+                'social_metrics': {},
+                'governance_metrics': {},
+                'analytics': {},
+                'trends': {},
+                'benchmarks': {},
+                'risk_analysis': {},
+                'predictions': {},
+                'recommendations': [
+                    {'category': 'data', 'recommendation': 'Report data not available. Please regenerate the report.'}
+                ],
+                'thresholds': {},
+                'custom_metrics': {},
+                'comparison_data': {}
+            }
+        except Exception:
+            # Ultimate fallback
+            return {
+                'report_info': {
+                    'name': 'ESG Report',
+                    'type': 'sustainability',
+                    'date_from': None,
+                    'date_to': None,
+                    'company': 'YourCompany',
+                    'generated_at': fields.Datetime.now().isoformat(),
+                    'total_assets': 0,
+                    'granularity': 'monthly',
+                    'theme': 'default',
+                    'note': 'Report data not available. Please regenerate the report.'
+                },
+                'environmental_metrics': {},
+                'social_metrics': {},
+                'governance_metrics': {},
+                'analytics': {},
+                'trends': {},
+                'benchmarks': {},
+                'risk_analysis': {},
+                'predictions': {},
+                'recommendations': [
+                    {'category': 'data', 'recommendation': 'Report data not available. Please regenerate the report.'}
+                ],
+                'thresholds': {},
+                'custom_metrics': {},
+                'comparison_data': {}
+            }
     
     safe_report_data = fields.Json(string='Safe Report Data', compute='_compute_safe_report_data', store=False)
     


### PR DESCRIPTION
Add robust error handling to ESG report template and wizard to prevent `NoneType` callable errors.

The `TypeError: 'NoneType' object is not callable` occurred because the QWeb template attempted to call a method (`_compute_safe_report_data_manual`) that was retrieved using `getattr(o, ..., None)`, which returned `None` when the wizard object `o` was not properly available or initialized in the template context. This PR introduces checks for the existence and callability of the method in the template, adds a `try-catch` block, and provides a default data structure in the wizard method to ensure the report renders gracefully even when data is missing or an error occurs during computation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c935d688-a57a-45aa-91b5-e075ffd180d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c935d688-a57a-45aa-91b5-e075ffd180d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>