### PR TITLE
Fix esg_reporting xml tag mismatch

### DIFF
--- a/odoo17/addons/esg_reporting/report/esg_report_templates.xml
+++ b/odoo17/addons/esg_reporting/report/esg_report_templates.xml
@@ -577,6 +577,8 @@
                             </t>
                             
                             <p><strong>Generated at:</strong> <t t-esc="context_timestamp(datetime.datetime.now())"/></p>
+                                </t>
+                            </t>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fix XML syntax error in `esg_report_templates.xml` by adding missing closing `</t>` tags.

The error `Opening and ending tag mismatch: div line 360 and t, line 570` was caused by an unclosed `<t t-if="o and o.id">` block starting at line 363. Adding the missing `</t>` tags resolves this XML parsing issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0af2073-bafc-459b-bbc0-80f67562d506">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0af2073-bafc-459b-bbc0-80f67562d506">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>