### PR TITLE
Changes from background agent bc-eeefb5a3-7329-4093-b6ae-089a50228bed

### DIFF
--- a/odoo17/addons/facilities_management/reports/sla_performance_report.xml
+++ b/odoo17/addons/facilities_management/reports/sla_performance_report.xml
@@ -152,7 +152,7 @@
 
                         <!-- Report Footer -->
                         <div style="margin-top:32px; padding-top:16px; border-top:1px solid #eee; text-align:center; color:#666; font-size:12px;">
-                            <p>Report generated on <span t-field="context_timestamp()"/></p>
+                            <p>Report generated on <span t-esc="context_timestamp()"/></p>
                             <p>This report provides insights into SLA performance and compliance metrics for the specified period.</p>
                         </div>
                     </div>


### PR DESCRIPTION
Fix QWeb error in SLA performance report by changing `t-field` to `t-esc` for `context_timestamp()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-eeefb5a3-7329-4093-b6ae-089a50228bed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eeefb5a3-7329-4093-b6ae-089a50228bed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>