### PR TITLE
Generate esg report with company id fix

### DIFF
--- a/odoo17/addons/esg_reporting/wizard/esg_report_wizard.py
+++ b/odoo17/addons/esg_reporting/wizard/esg_report_wizard.py
@@ -232,6 +232,8 @@ class EnhancedESGWizard(models.TransientModel):
 
     # Company Information
     company_name = fields.Char(string='Company', default='YourCompany')
+    company_id = fields.Many2one('res.company', string='Company',
+                                 default=lambda self: self.env.company)
 
     # Report data storage for template access
     report_data = fields.Json(string='Report Data', readonly=True, default={})


### PR DESCRIPTION
Add `company_id` field to `EnhancedESGWizard` model to resolve `AttributeError` during report generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-42960b0e-48b5-4913-ab2a-c8f73113d205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42960b0e-48b5-4913-ab2a-c8f73113d205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>