### PR TITLE
Fix esg analytics dashboard data argument error

### DIFF
--- a/odoo17/addons/esg_reporting/models/esg_analytics.py
+++ b/odoo17/addons/esg_reporting/models/esg_analytics.py
@@ -136,9 +136,15 @@ class ESGAnalytics(models.Model):
         """Reset to draft state"""
         self.write({'state': 'draft'})
 
-    def get_comprehensive_dashboard_data(self, period='current_year', category='all'):
+    def get_comprehensive_dashboard_data(self, period=None, category=None):
         """Get comprehensive dashboard data for the frontend"""
         self.ensure_one()
+        
+        # Set default values if None
+        if period is None:
+            period = 'current_year'
+        if category is None:
+            category = 'all'
         
         # Calculate date range based on period
         today = fields.Date.today()
@@ -248,9 +254,15 @@ class ESGAnalytics(models.Model):
 
         return alerts
 
-    def generate_comprehensive_report(self, period='current_year', category='all'):
+    def generate_comprehensive_report(self, period=None, category=None):
         """Generate comprehensive ESG report"""
         self.ensure_one()
+        
+        # Set default values if None
+        if period is None:
+            period = 'current_year'
+        if category is None:
+            category = 'all'
         
         # This would generate a PDF report
         # For now, return mock data
@@ -260,9 +272,15 @@ class ESGAnalytics(models.Model):
             'generated_at': fields.Datetime.now().isoformat()
         }
 
-    def export_dashboard_data(self, period='current_year', category='all'):
+    def export_dashboard_data(self, period=None, category=None):
         """Export dashboard data as CSV"""
         self.ensure_one()
+        
+        # Set default values if None
+        if period is None:
+            period = 'current_year'
+        if category is None:
+            category = 'all'
         
         dashboard_data = self.get_comprehensive_dashboard_data(period, category)
         


### PR DESCRIPTION
Fix TypeError in ESG analytics methods by handling default parameters correctly.

The original method signatures with default keyword arguments (e.g., `period='current_year'`) caused a `TypeError` when called from the frontend with positional arguments. By changing default parameters to `None` and explicitly setting the default values inside the method, the methods can correctly accept both positional and keyword arguments, resolving the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4545da8-aa0f-4eaf-8593-85216e3cc580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a4545da8-aa0f-4eaf-8593-85216e3cc580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>