### PR TITLE
Fix missing menu item external id

### DIFF
--- a/odoo17/addons/facilities_management/views/sla_views.xml
+++ b/odoo17/addons/facilities_management/views/sla_views.xml
@@ -233,7 +233,7 @@
         <!-- SLA Menu -->
         <menuitem id="menu_facilities_sla"
                   name="SLAs"
-                  parent="menu_facilities_maintenance"
+                  parent="menu_maintenance"
                   action="action_facilities_sla"
                   sequence="20"/>
 


### PR DESCRIPTION
Fixes module installation error by correcting the parent menu reference for SLAs.

The `menu_facilities_sla` menu was referencing a non-existent parent `menu_facilities_maintenance`, causing a `ValueError: External ID not found` during module loading. This PR updates the parent to the correct and existing `menu_maintenance`.

---
<a href="https://cursor.com/background-agent?bcId=bc-51b4c7d7-6cfc-4f58-9224-34e7475c6433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51b4c7d7-6cfc-4f58-9224-34e7475c6433">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

