### PR TITLE
Odoo module loading with xml syntax error

### DIFF
--- a/odoo17/addons/facilities_management/views/facilities_import_wizard_views.xml
+++ b/odoo17/addons/facilities_management/views/facilities_import_wizard_views.xml
@@ -95,5 +95,4 @@
               parent="menu_facilities_config"
               action="action_facilities_import_wizard"
               sequence="100"/>
-    </data>
 </odoo>


### PR DESCRIPTION
Remove extraneous `</data>` tag in `facilities_import_wizard_views.xml` to fix XML parsing error.

---
<a href="https://cursor.com/background-agent?bcId=bc-586bd802-187a-4649-b457-82754ee7079d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-586bd802-187a-4649-b457-82754ee7079d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

