### PR TITLE
Odoo module loading error: missing menu parent

### DIFF
--- a/FACILITIES_MANAGEMENT_MENU_FIX_SUMMARY.md
+++ b/FACILITIES_MANAGEMENT_MENU_FIX_SUMMARY.md
@@ -1,0 +1,70 @@
+# Facilities Management Module Menu Fix Summary
+
+## Problem Identified
+
+The `facilities_management` module was failing to install/update due to a menu reference error:
+
+```
+ValueError: External ID not found in the system: facilities_management.menu_facilities_maintenance
+```
+
+This error occurred in the file `odoo17/addons/facilities_management/views/sla_views.xml` at line 240, where a menu item was trying to reference a parent menu that didn't exist.
+
+## Root Cause
+
+In `odoo17/addons/facilities_management/views/sla_views.xml`, the SLA menu was defined as:
+
+```xml
+<menuitem id="menu_facilities_sla"
+          name="SLAs"
+          parent="menu_facilities_maintenance"  <!-- This menu didn't exist -->
+          action="action_facilities_sla"
+          sequence="20"/>
+```
+
+The `menu_facilities_maintenance` menu item was referenced but never defined in the module.
+
+## Solution Applied
+
+Changed the parent menu reference from the non-existent `menu_facilities_maintenance` to the existing `menu_maintenance` menu:
+
+```xml
+<menuitem id="menu_facilities_sla"
+          name="SLAs"
+          parent="menu_maintenance"  <!-- Changed to existing menu -->
+          action="action_facilities_sla"
+          sequence="25"/>  <!-- Updated sequence for better organization -->
+```
+
+## Files Modified
+
+- `odoo17/addons/facilities_management/views/sla_views.xml` (line 237)
+
+## Verification
+
+The fix was verified by:
+1. ✅ Confirming no remaining references to `menu_facilities_maintenance` exist in the module
+2. ✅ Checking that `menu_maintenance` exists and is properly defined
+3. ✅ Verifying that the `action_facilities_sla` action is properly defined
+4. ✅ Confirming that the `facilities.sla` model exists and is properly imported
+
+## Menu Structure
+
+The SLA menu is now properly placed under the Maintenance section:
+```
+Facility Management
+└── Maintenance
+    └── SLAs (new location)
+```
+
+This provides a logical organization where SLAs are grouped with other maintenance-related functionality.
+
+## Additional Notes
+
+- The module has other dependencies (like `psycopg2`) that need to be installed separately
+- The menu fix resolves the specific XML parsing error that was preventing module installation
+- All other menu references in the module have been verified to exist
+
+## Status
+
+✅ **FIXED**: The menu reference error has been resolved. The `facilities_management` module should now install without the `ValueError: External ID not found in the system: facilities_management.menu_facilities_maintenance` error.

--- a/odoo17/addons/facilities_management/views/sla_views.xml
+++ b/odoo17/addons/facilities_management/views/sla_views.xml
@@ -235,9 +235,9 @@
         <!-- SLA Menu -->
         <menuitem id="menu_facilities_sla"
                   name="SLAs"
-                  parent="menu_facilities_maintenance"
+                  parent="menu_maintenance"
                   action="action_facilities_sla"
-                  sequence="20"/>
+                  sequence="25"/>
 
         <!-- Enhanced Work Order Form View -->
         <record id="view_maintenance_workorder_enhanced_form" model="ir.ui.view">

--- a/test_module_fix.py
+++ b/test_module_fix.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Test script to verify that the facilities_management module can be installed
+without the menu reference error.
+"""
+
+import os
+import sys
+import subprocess
+import tempfile
+import shutil
+
+def test_module_installation():
+    """Test if the module can be installed without errors."""
+    
+    print("Testing facilities_management module installation...")
+    
+    # Check if we're in the right directory
+    if not os.path.exists("odoo17/odoo-bin"):
+        print("Error: odoo-bin not found. Please run this script from the workspace root.")
+        return False
+    
+    # Try to find Python executable
+    python_cmd = None
+    possible_paths = [
+        "/home/ranjith/odoo17env/bin/python",
+        "python3",
+        "python",
+        sys.executable
+    ]
+    
+    for path in possible_paths:
+        try:
+            result = subprocess.run([path, "--version"], 
+                                  capture_output=True, text=True, timeout=5)
+            if result.returncode == 0:
+                python_cmd = path
+                print(f"Using Python: {path}")
+                break
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            continue
+    
+    if not python_cmd:
+        print("Error: Could not find a working Python executable")
+        return False
+    
+    # Test the module installation
+    try:
+        cmd = [
+            python_cmd, "odoo17/odoo-bin",
+            "-d", "odoo17",
+            "-u", "facilities_management",
+            "--stop-after-init",
+            "--log-level=error"
+        ]
+        
+        print(f"Running command: {' '.join(cmd)}")
+        
+        result = subprocess.run(cmd, 
+                              capture_output=True, 
+                              text=True, 
+                              timeout=60,
+                              cwd=".")
+        
+        if result.returncode == 0:
+            print("✅ SUCCESS: Module installed without errors!")
+            return True
+        else:
+            print("❌ ERROR: Module installation failed")
+            print("STDOUT:", result.stdout)
+            print("STDERR:", result.stderr)
+            return False
+            
+    except subprocess.TimeoutExpired:
+        print("❌ ERROR: Installation timed out")
+        return False
+    except Exception as e:
+        print(f"❌ ERROR: {e}")
+        return False
+
+def check_menu_references():
+    """Check for any remaining problematic menu references."""
+    
+    print("\nChecking for problematic menu references...")
+    
+    # Check for the specific error we fixed
+    sla_file = "odoo17/addons/facilities_management/views/sla_views.xml"
+    
+    if os.path.exists(sla_file):
+        with open(sla_file, 'r') as f:
+            content = f.read()
+            
+        if 'menu_facilities_maintenance' in content:
+            print("❌ ERROR: Found reference to non-existent menu_facilities_maintenance")
+            return False
+        else:
+            print("✅ SUCCESS: No references to menu_facilities_maintenance found")
+            return True
+    else:
+        print("❌ ERROR: SLA views file not found")
+        return False
+
+def main():
+    """Main test function."""
+    print("=" * 60)
+    print("FACILITIES MANAGEMENT MODULE FIX TEST")
+    print("=" * 60)
+    
+    # Check menu references first
+    menu_ok = check_menu_references()
+    
+    if not menu_ok:
+        print("\n❌ Menu reference check failed. Please fix the issues first.")
+        return False
+    
+    # Test module installation
+    install_ok = test_module_installation()
+    
+    if install_ok:
+        print("\n🎉 ALL TESTS PASSED!")
+        print("The facilities_management module should now install without the menu reference error.")
+    else:
+        print("\n❌ Some tests failed. Please check the errors above.")
+    
+    return install_ok
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Fixes module installation by correcting a non-existent menu reference in `sla_views.xml`.

The `facilities_management` module failed to install due to a `ValueError` because the SLA menu item referenced `menu_facilities_maintenance`, which was not defined. This PR updates the parent menu to the existing `menu_maintenance`, allowing the module to load correctly and placing the SLA menu under the appropriate Maintenance section.

---
<a href="https://cursor.com/background-agent?bcId=bc-00fa3ecf-91b4-485f-b1b0-1b4cfec8e440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00fa3ecf-91b4-485f-b1b0-1b4cfec8e440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

