### PR TITLE
Fix missing view external id

### DIFF
--- a/odoo17/addons/facilities_management/__manifest__.py
+++ b/odoo17/addons/facilities_management/__manifest__.py
@@ -63,7 +63,6 @@ Features:
 
         # Views - Assets
         'views/asset_calendar_views.xml',
-        'views/facility_asset_menus.xml',
         'views/facility_asset_views.xml',
         'views/asset_category_views.xml',
         'views/asset_dashboard_views.xml',
@@ -88,6 +87,9 @@ Features:
         'views/maintenance_job_plan_views.xml',
         'views/maintenance_report_views.xml',
         'views/maintenance_workorder_calendar_views.xml',
+
+        # Views - Menus (moved after all other views are loaded)
+        'views/facility_asset_menus.xml',
 
         # Views - Other
         'views/sla_views.xml',


### PR DESCRIPTION
Reorder XML file loading in manifest to resolve 'External ID not found' error.

The `facility_asset_menus.xml` file was attempting to reference views (e.g., `view_maintenance_workorder_enhanced_tree`) before their definitions were loaded. Moving the menu file to load after all view definitions ensures that all referenced external IDs are available during module initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-21530ead-b47d-4a8f-94b0-c8684eb8d65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21530ead-b47d-4a8f-94b0-c8684eb8d65e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

