### PR TITLE
Odoo facilities management import error

### DIFF
--- a/odoo17/addons/facilities_management/models/__init__.py
+++ b/odoo17/addons/facilities_management/models/__init__.py
@@ -13,7 +13,8 @@ _logger = logging.getLogger(__name__)
 from . import hr_employee
 from . import product
 from . import maintenance_team
-# maintenance_job_plan_task is defined in maintenance_job_plan.py, so don't import separately
+from . import maintenance_job_plan_section
+from . import maintenance_job_plan_task
 from . import maintenance_job_plan    # Loads both job plan and its tasks
 
 # 2. Core Infrastructure & Assets (Hierarchical, depends on basic Odoo models)
@@ -34,13 +35,11 @@ from . import asset_performance
 
 # 4. Transactional Models (Depend on many of the above)
 from . import maintenance_workorder
+from . import maintenance_workorder_inheritance
 from . import maintenance_workorder_assignment
 from . import maintenance_workorder_part_line
-from . import maintenance_workorder_task
-from . import maintenance_job_plan_section
-from . import maintenance_job_plan_task
-from . import maintenance_job_plan
 from . import maintenance_workorder_section
+from . import maintenance_workorder_task
 from . import stock_picking
 
 # 5. Scheduled/Predictive Maintenance (Often depend on assets and work orders)

--- a/odoo17/addons/facilities_management/models/maintenance_workorder_inheritance.py
+++ b/odoo17/addons/facilities_management/models/maintenance_workorder_inheritance.py
@@ -1,0 +1,27 @@
+from odoo import fields, models, api, _
+from odoo.exceptions import ValidationError, UserError
+
+class MaintenanceWorkorder(models.Model):
+    _inherit = 'maintenance.workorder'
+
+    show_tasks_to_complete_btn = fields.Boolean(
+        compute="_compute_show_tasks_to_complete_btn",
+        string="Show Tasks to Complete Button"
+    )
+
+    @api.depends('work_order_type')
+    def _compute_show_tasks_to_complete_btn(self):
+        for rec in self:
+            rec.show_tasks_to_complete_btn = rec.work_order_type == 'preventive'
+
+    def action_open_job_plan_tasks_mobile(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'name': _('Tasks to Complete'),
+            'res_model': 'maintenance.workorder.task',
+            'view_mode': 'tree,form',
+            'domain': [('workorder_id', '=', self.id), ('is_done', '=', False)],
+            'context': {'default_workorder_id': self.id},
+            'target': 'current',
+        }

--- a/odoo17/addons/facilities_management/models/maintenance_workorder_task.py
+++ b/odoo17/addons/facilities_management/models/maintenance_workorder_task.py
@@ -1,31 +1,6 @@
 from odoo import fields, models, api, _
 from odoo.exceptions import ValidationError, UserError
 
-class MaintenanceWorkorder(models.Model):
-    _inherit = 'maintenance.workorder'
-
-    show_tasks_to_complete_btn = fields.Boolean(
-        compute="_compute_show_tasks_to_complete_btn",
-        string="Show Tasks to Complete Button"
-    )
-
-    @api.depends('work_order_type')
-    def _compute_show_tasks_to_complete_btn(self):
-        for rec in self:
-            rec.show_tasks_to_complete_btn = rec.work_order_type == 'preventive'
-
-    def action_open_job_plan_tasks_mobile(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _('Tasks to Complete'),
-            'res_model': 'maintenance.workorder.task',
-            'view_mode': 'tree,form',
-            'domain': [('workorder_id', '=', self.id), ('is_done', '=', False)],
-            'context': {'default_workorder_id': self.id},
-            'target': 'current',
-        }
-
 class MaintenanceWorkorderTask(models.Model):
     _name = 'maintenance.workorder.task'
     _description = 'Maintenance Work Order Task'


### PR DESCRIPTION
Refactor `facilities_management` module to resolve circular import by separating `MaintenanceWorkorder` inheritance.

The circular import was caused by `maintenance_workorder_task.py` defining both the `MaintenanceWorkorder` (inheriting from `maintenance.workorder`) and `MaintenanceWorkorderTask` models, while `maintenance_workorder.py` referenced `maintenance.workorder.task`. Moving the `MaintenanceWorkorder` inheritance to a dedicated file (`maintenance_workorder_inheritance.py`) and updating `__init__.py` eliminates this dependency loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-17e2fb76-b0e1-4a12-857f-c1d24bbf24a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17e2fb76-b0e1-4a12-857f-c1d24bbf24a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

