### PR TITLE
Remove work order menu items

### DIFF
--- a/odoo17/addons/facilities_management/views/facility_asset_menus.xml
+++ b/odoo17/addons/facilities_management/views/facility_asset_menus.xml
@@ -528,23 +528,7 @@
               action="action_maintenance_workorder"
               sequence="10"/>
 
-    <menuitem id="menu_maintenance_workorder_tasks"
-              name="Work Order Tasks"
-              parent="menu_maintenance_operations"
-              action="action_maintenance_workorder_task"
-              sequence="15"/>
 
-    <menuitem id="menu_maintenance_workorder_assignments"
-              name="Work Order Assignments"
-              parent="menu_maintenance_operations"
-              action="action_maintenance_workorder_assignment"
-              sequence="17"/>
-
-    <menuitem id="menu_maintenance_workorder_sections"
-              name="Work Order Sections"
-              parent="menu_maintenance_operations"
-              action="action_maintenance_workorder_section"
-              sequence="19"/>
 
     <menuitem id="menu_maintenance_schedule"
               name="Schedules"


### PR DESCRIPTION
Remove "Work Order Tasks", "Work Order Assignments", and "Work Order Sections" menu items as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8077027-b6b0-4d76-a714-d1f390b0359d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8077027-b6b0-4d76-a714-d1f390b0359d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

