### PR TITLE
Fix missing workorder tree view external id

### DIFF
--- a/odoo17/addons/facilities_management/__manifest__.py
+++ b/odoo17/addons/facilities_management/__manifest__.py
@@ -79,6 +79,7 @@ Features:
 
         # Views - Maintenance
         'views/maintenance_team_views.xml',
+        'views/maintenance_workorder_views.xml',
         'views/maintenance_workorder_part_line_views.xml',
         'views/maintenance_workorder_permit_views.xml',
         'views/maintenance_workorder_kanban.xml',


### PR DESCRIPTION
Adds missing `maintenance_workorder_views.xml` to manifest to resolve 'External ID not found' error during module upgrade.

The error "External ID not found in the system: facilities_management.view_maintenance_workorder_enhanced_tree" occurred because the `maintenance_workorder_views.xml` file, which defines the `view_maintenance_workorder_tree` and `view_workorder_form` views, was not included in the module's `__manifest__.py`. This prevented Odoo from loading these views, causing the action (`action_maintenance_workorder`) to fail when referencing them. Adding the file to the manifest ensures the views are properly loaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-206c817d-cf38-40a9-95c2-082158b087f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-206c817d-cf38-40a9-95c2-082158b087f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

