### PR TITLE
Fix workorder form view display

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -3,6 +3,7 @@
     <record id="view_workorder_form" model="ir.ui.view">
         <field name="name">maintenance.workorder.form</field>
         <field name="model">maintenance.workorder</field>
+        <field name="priority" eval="25"/>
         <field name="arch" type="xml">
             <form>
                 <header>
@@ -170,6 +171,7 @@
     <record id="view_maintenance_workorder_tree" model="ir.ui.view">
         <field name="name">maintenance.workorder.tree</field>
         <field name="model">maintenance.workorder</field>
+        <field name="priority" eval="25"/>
         <field name="arch" type="xml">
             <tree decoration-success="status=='done'"
                   decoration-danger="status=='cancelled'"


### PR DESCRIPTION
Set higher priority for desktop workorder form and tree views to ensure they display instead of mobile views.

The mobile workorder views had a default priority of 20, while the desktop views defaulted to 16. This caused the mobile view to be displayed even on desktop. By setting the desktop views' priority to 25, they now correctly take precedence.

---
<a href="https://cursor.com/background-agent?bcId=bc-3470e439-b71d-41ac-ad11-b99fef8a5e55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3470e439-b71d-41ac-ad11-b99fef8a5e55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

