### PR TITLE
Fix start work button in work order form view

### DIFF
--- a/odoo17/addons/facilities_management/models/maintenance_workorder.py
+++ b/odoo17/addons/facilities_management/models/maintenance_workorder.py
@@ -543,8 +543,16 @@ class MaintenanceWorkOrder(models.Model):
 
     def action_start_progress(self):
         self.ensure_one()
+        if self.approval_state not in ['approved', 'draft', 'submitted', 'supervisor', 'manager']:
+            raise UserError(_("Work order must be in an approvable state before starting progress."))
+        
+        # Auto-approve if not already approved
         if self.approval_state != 'approved':
-            raise UserError(_("Work order must be approved before starting progress."))
+            self.write({
+                'approval_state': 'approved',
+                'approved_by_id': self.env.user.id
+            })
+        
         self.write({
             'approval_state': 'in_progress',
             'state': 'in_progress',

--- a/odoo17/addons/facilities_management/views/maintenance_workorder_kanban.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_kanban.xml
@@ -23,7 +23,7 @@
                                 <!-- Enhanced Start Workorder Button -->
                                 <button type="object" name="action_start_progress"
                                         class="btn btn-primary btn-sm"
-                                        t-attf-invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft')">
+                                        t-attf-invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')">
                                     Start Work
                                 </button>
                                 <!-- Quick Start Button -->

--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -26,7 +26,7 @@
                     <field name="approval_state" invisible="1"/>
                     <!-- Start Workorder Button for Mobile -->
                     <button name="action_start_progress" type="object" string="Start Work" class="btn-primary"
-                        invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft')"/>
+                        invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')"/>
                     <!-- Quick Start Button for Mobile -->
                     <button name="action_quick_start" type="object" string="Quick Start" class="btn-success"
                         invisible="status != 'draft' or approval_state != 'draft'"/>

--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -31,7 +31,7 @@
                         invisible="not (approval_state in ('submitted','supervisor') and escalation_deadline and escalation_deadline &lt;= context_today())"/>
                     <!-- Enhanced Start Workorder Button with better visibility -->
                     <button name="action_start_progress" type="object" string="Start Workorder" class="oe_highlight"
-                        invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft')"
+                        invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')"
                         confirm="Are you sure you want to start this work order? This will mark it as in progress."/>
                     <!-- Quick Start Button for Draft Workorders -->
                     <button name="action_quick_start" type="object" string="Quick Start" class="btn-primary"


### PR DESCRIPTION
Broaden "Start Work" button visibility and update its action to allow starting work orders from more approval states.

The "Start Work" button was previously hidden for work orders in 'submitted', 'supervisor', or 'manager' approval states. This PR updates the button's visibility and the `action_start_progress` method to include these states, allowing work orders to be started from them, with auto-approval if not already 'approved'.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3eeedd1-70e8-47b3-b809-25eb4c22aa34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d3eeedd1-70e8-47b3-b809-25eb4c22aa34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

