### PR TITLE
Fix start button visibility on approved work orders

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -31,7 +31,7 @@
                         invisible="not (approval_state in ('submitted','supervisor') and escalation_deadline and escalation_deadline &lt;= context_today())"/>
                     <!-- Enhanced Start Workorder Button with better visibility -->
                     <button name="action_start_progress" type="object" string="Start Workorder" class="oe_highlight"
-                        invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')"
+                        invisible="approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager') or (approval_state != 'approved' and status not in ('draft', 'assigned'))"
                         confirm="Are you sure you want to start this work order? This will mark it as in progress."/>
                     <!-- Quick Start Button for Draft Workorders -->
                     <button name="action_quick_start" type="object" string="Quick Start" class="btn-primary"


### PR DESCRIPTION
Make the "Start Workorder" button visible for approved work orders.

The previous visibility condition incorrectly required the `status` to be 'draft' or 'assigned' even when `approval_state` was 'approved', preventing the button from appearing. This update ensures the button is visible when `approval_state` is 'approved', while maintaining existing logic for other approval states.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba45a9c8-b170-4ab5-b66d-786ecee65dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba45a9c8-b170-4ab5-b66d-786ecee65dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

