### PR TITLE
Fix label for attribute in xml view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -104,21 +104,21 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Asset:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Asset:</label>
                                     <p class="text-dark"><field name="asset_id" readonly="1"/></p>
                                 </div>
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Building:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Building:</label>
                                     <p class="text-dark"><field name="building_id" readonly="1"/></p>
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Facility:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Facility:</label>
                                     <p class="text-dark"><field name="facility_id" readonly="1"/></p>
                                 </div>
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Room:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Room:</label>
                                     <p class="text-dark"><field name="room_id" readonly="1"/></p>
                                 </div>
                             </div>
@@ -133,21 +133,21 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Description:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Description:</label>
                                     <p class="text-dark"><field name="description" readonly="1"/></p>
                                 </div>
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Technician:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Technician:</label>
                                     <p class="text-dark"><field name="technician_id" readonly="1"/></p>
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">Start Date:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">Start Date:</label>
                                     <p class="text-dark"><field name="start_date" readonly="1"/></p>
                                 </div>
                                 <div class="col-6">
-                                    <label class="text-dark font-weight-bold">End Date:</label>
+                                    <label class="o_form_label text-dark font-weight-bold">End Date:</label>
                                     <p class="text-dark"><field name="end_date" readonly="1"/></p>
                                 </div>
                             </div>


### PR DESCRIPTION
Adds `o_form_label` class to label tags in `maintenance_workorder_mobile_form.xml` to resolve an Odoo XML parsing error.

The error "Label tag must contain a 'for'" occurred because `<label>` tags used as section headers were missing either a `for` attribute or the `o_form_label` class, which is required for labels without corresponding fields. Adding `o_form_label` ensures compliance with Odoo's XML validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2ec5507-760a-470a-b50c-402ed5c1611e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2ec5507-760a-470a-b50c-402ed5c1611e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

