### PR TITLE
Fix missing xml template and modules

### DIFF
--- a/odoo17/addons/facilities_management/static/src/xml/mobile_workorders_enhanced.xml
+++ b/odoo17/addons/facilities_management/static/src/xml/mobile_workorders_enhanced.xml
@@ -10,7 +10,7 @@
               <div>
                 <div class="fw-bold" t-esc="wo.name"/>
                 <small class="text-muted">
-                  <t t-esc="wo.asset_id && wo.asset_id[1] || ''"/>
+                  <t t-esc="wo.asset_id ? wo.asset_id[1] : ''"/>
                   <t t-if="wo.building_id"> • <t t-esc="wo.building_id[1]"/></t>
                 </small>
               </div>
@@ -37,7 +37,7 @@
               <div>
                 <div class="fw-bold" t-esc="wo.name"/>
                 <small class="text-muted">
-                  <t t-esc="wo.asset_id && wo.asset_id[1] || ''"/>
+                  <t t-esc="wo.asset_id ? wo.asset_id[1] : ''"/>
                   <t t-if="wo.building_id"> • <t t-esc="wo.building_id[1]"/></t>
                 </small>
               </div>


### PR DESCRIPTION
Fixes "Invalid XML template" error by replacing unsupported `&&` and `||` JavaScript operators with the QWeb-compatible ternary operator in `t-esc` attributes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a284e594-5e5b-471f-be7f-6370acbb3feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a284e594-5e5b-471f-be7f-6370acbb3feb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

