### PR TITLE
Fix forbidden owl directive in view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -71,6 +71,10 @@
                                 invisible="workorder_task_ids != False"
                                 readonly="status != 'draft'"
                                 help="Select a Job Plan to automatically populate tasks for this work order."/>
+                            <div class="alert alert-warning mt-2"
+                                 attrs="{'invisible': [('work_order_type', '!=', 'preventive'), ('job_plan_id', '!=', False)]}">
+                                No job plan linked. Tasks are not available.
+                            </div>
                             <field name="service_type"/>
                             <field name="maintenance_team_id"/>
                         </group>


### PR DESCRIPTION
Replace forbidden `t-if` with `attrs` in XML view to resolve `ParseError`.

The error traceback explicitly states "Forbidden owl directive used in arch (t-if)". Standard Odoo XML views do not support OWL directives for conditional rendering; `attrs` must be used instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-938bc2bb-22ab-4674-b20c-52d2f442fbd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-938bc2bb-22ab-4674-b20c-52d2f442fbd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

