### PR TITLE
Fix invalid xml view definition

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -71,8 +71,7 @@
                                 invisible="workorder_task_ids != False"
                                 readonly="status != 'draft'"
                                 help="Select a Job Plan to automatically populate tasks for this work order."/>
-                            <div class="alert alert-warning mt-2"
-                                 attrs="{'invisible': [('work_order_type', '!=', 'preventive'), ('job_plan_id', '!=', False)]}">
+                            <div class="alert alert-warning mt-2" t-if="work_order_type == 'preventive' and job_plan_id != False">
                                 No job plan linked. Tasks are not available.
                             </div>
                             <field name="service_type"/>


### PR DESCRIPTION
Replace deprecated `attrs` with `t-if` in `maintenance_workorder_views.xml` to resolve `ParseError` in Odoo 17.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c26ab1c-770e-489c-aa17-af649f68a139">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c26ab1c-770e-489c-aa17-af649f68a139">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

