### PR TITLE
Fix invalid xml view definition

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_views.xml
@@ -71,7 +71,7 @@
                                 invisible="workorder_task_ids != False"
                                 readonly="status != 'draft'"
                                 help="Select a Job Plan to automatically populate tasks for this work order."/>
-                            <div attrs="{'invisible': [('show_job_plan_warning', '=', False)]}" class="o_form_label alert alert-warning mt-2">
+                            <div modifiers="{'invisible': [('show_job_plan_warning', '=', False)]}" class="o_form_label alert alert-warning mt-2">
                                 No job plan linked. Tasks are not available.
                             </div>
                             <field name="service_type"/>


### PR DESCRIPTION
Replace deprecated `attrs` with `modifiers` in `maintenance_workorder_views.xml` to resolve Odoo 17 `ParseError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fb6a6d2-bfe8-40db-9041-877eae21d801">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fb6a6d2-bfe8-40db-9041-877eae21d801">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

