### PR TITLE
Add before and after image capture to task item

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -167,41 +167,17 @@
                             </div>
 
                             <field name="workorder_task_ids" create="false" invisible="not (schedule_id and job_plan_id)">
-                                <tree editable="bottom">
+                                <tree>
                                     <field name="section_id"/>
                                     <field name="name" readonly="1"/>
                                     <field name="description" readonly="1"/>
-                                    <field name="is_done" widget="boolean_toggle" readonly="workorder_status != 'in_progress'"/>
+                                    <field name="is_done" widget="boolean_toggle" readonly="workorder_id.state != 'in_progress'"/>
                                     <field name="before_image" widget="image" optional="show" string="Before"/>
                                     <field name="after_image" widget="image" optional="show" string="After"/>
-                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="workorder_status != 'in_progress'"/>
+                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="workorder_id.state != 'in_progress'"/>
+                                    <button name="action_view_task_mobile" type="object" string="Edit Task" class="btn btn-primary btn-sm"/>
+                                    <button name="action_row_click_mobile" type="object" string="Open Task" class="btn btn-link btn-sm" invisible="1"/>
                                 </tree>
-                                <form string="Task">
-                                    <header>
-                                        <field name="workorder_status" invisible="1"/>
-                                        <div class="alert alert-info" role="alert" invisible="workorder_status == 'in_progress'">
-                                            <i class="fa fa-info-circle me-2"></i>
-                                            <strong>Work Order must be "In Progress" to complete tasks and upload images.</strong>
-                                        </div>
-                                    </header>
-                                    <group>
-                                        <group>
-                                            <field name="section_id" readonly="1"/>
-                                            <field name="name" readonly="1"/>
-                                        </group>
-                                        <field name="description" readonly="1"/>
-                                        <field name="is_done" widget="boolean_toggle" readonly="workorder_status != 'in_progress'"/>
-                                        <group string="Before/After Images" invisible="workorder_status != 'in_progress'">
-                                            <field name="before_image" widget="image" string="Before Image" help="Upload image before starting the task"/>
-                                            <field name="after_image" widget="image" string="After Image" help="Upload image after completing the task"/>
-                                        </group>
-                                        <group string="Images (Read-only)" invisible="workorder_status == 'in_progress'">
-                                            <field name="before_image" widget="image" string="Before Image" readonly="1"/>
-                                            <field name="after_image" widget="image" string="After Image" readonly="1"/>
-                                        </group>
-                                        <field name="notes" placeholder="Add notes about the task execution..." readonly="workorder_status not in ('in_progress',)"/>
-                                    </group>
-                                </form>
                             </field>
                         </div>
                     </div>

--- a/odoo17/addons/facilities_management/views/maintenance_workorder_task_actions.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_task_actions.xml
@@ -1,5 +1,83 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
+    <!-- Mobile Form View for Maintenance Workorder Tasks -->
+    <record id="view_maintenance_workorder_task_mobile_form" model="ir.ui.view">
+        <field name="name">maintenance.workorder.task.mobile.form</field>
+        <field name="model">maintenance.workorder.task</field>
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <form string="Task (Mobile)" class="o_mobile_form">
+                <header>
+                    <field name="workorder_id" invisible="1"/>
+                    <div class="alert alert-info" role="alert" invisible="workorder_id.state == 'in_progress'">
+                        <i class="fa fa-info-circle me-2"></i>
+                        <strong>Work Order must be "In Progress" to complete tasks and upload images.</strong>
+                    </div>
+                </header>
+                
+                <sheet>
+                    <div class="oe_title text-center mb-4">
+                        <h2 class="text-primary"><field name="name" readonly="1"/></h2>
+                        <p class="text-muted"><field name="section_id" readonly="1"/></p>
+                    </div>
+
+                    <div class="card border-0 shadow-sm mb-4">
+                        <div class="card-header bg-info text-white">
+                            <h5 class="mb-0"><i class="fa fa-info-circle me-2"></i>Task Details</h5>
+                        </div>
+                        <div class="card-body">
+                            <field name="description" readonly="1"/>
+                            <field name="is_done" widget="boolean_toggle" readonly="workorder_id.state != 'in_progress'" string="Mark as Complete"/>
+                        </div>
+                    </div>
+
+                    <div class="card border-0 shadow-sm mb-4" invisible="workorder_id.state != 'in_progress'">
+                        <div class="card-header bg-warning text-white">
+                            <h5 class="mb-0"><i class="fa fa-camera me-2"></i>Before/After Images</h5>
+                        </div>
+                        <div class="card-body">
+                            <group>
+                                <field name="before_image" widget="image" string="Before Image" help="Upload image before starting the task"/>
+                                <field name="after_image" widget="image" string="After Image" help="Upload image after completing the task"/>
+                            </group>
+                        </div>
+                    </div>
+
+                    <div class="card border-0 shadow-sm mb-4" invisible="workorder_id.state == 'in_progress'">
+                        <div class="card-header bg-secondary text-white">
+                            <h5 class="mb-0"><i class="fa fa-camera me-2"></i>Images (Read-only)</h5>
+                        </div>
+                        <div class="card-body">
+                            <group>
+                                <field name="before_image" widget="image" string="Before Image" readonly="1"/>
+                                <field name="after_image" widget="image" string="After Image" readonly="1"/>
+                            </group>
+                        </div>
+                    </div>
+
+                    <div class="card border-0 shadow-sm mb-4">
+                        <div class="card-header bg-success text-white">
+                            <h5 class="mb-0"><i class="fa fa-sticky-note me-2"></i>Notes</h5>
+                        </div>
+                        <div class="card-body">
+                            <field name="notes" placeholder="Add notes about the task execution..." readonly="workorder_id.state not in ('in_progress',)"/>
+                        </div>
+                    </div>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <!-- Mobile Action for Tasks -->
+    <record id="action_maintenance_workorder_task_mobile" model="ir.actions.act_window">
+        <field name="name">Task (Mobile)</field>
+        <field name="res_model">maintenance.workorder.task</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="facilities_management.view_maintenance_workorder_task_mobile_form"/>
+        <field name="target">current</field>
+        <field name="context">{'mobile_view': True}</field>
+    </record>
+
     <!-- Action for uploading before image - Commented out as we're using object methods instead -->
     <!--
     <record id="action_upload_before_image" model="ir.actions.act_window">


### PR DESCRIPTION
Enables dedicated mobile form for maintenance tasks, fixing task item click and toggle button issues.

Previously, clicking on task items in the mobile workorder form did not open a functional detail view, and the task completion toggle was broken due to incorrect field references. This PR introduces a dedicated mobile form for tasks, accessible via an 'Edit Task' button, ensuring technicians can properly upload before/after images and manage task completion.

---
<a href="https://cursor.com/background-agent?bcId=bc-9556e2fd-dd03-462a-90b3-3319b783cb69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9556e2fd-dd03-462a-90b3-3319b783cb69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

