### PR TITLE
Fix missing field in mobile work order view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -171,10 +171,10 @@
                                     <field name="section_id"/>
                                     <field name="name" readonly="1"/>
                                     <field name="description" readonly="1"/>
-                                    <field name="is_done" widget="boolean_toggle" readonly="workorder_id.state != 'in_progress'"/>
+                                    <field name="is_done" widget="boolean_toggle" readonly="state != 'in_progress'"/>
                                     <field name="before_image" widget="image" optional="show" string="Before"/>
                                     <field name="after_image" widget="image" optional="show" string="After"/>
-                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="workorder_id.state != 'in_progress'"/>
+                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="state != 'in_progress'"/>
                                     <button name="action_view_task_mobile" type="object" string="Edit Task" class="btn btn-primary btn-sm"/>
                                     <button name="action_row_click_mobile" type="object" string="Open Task" class="btn btn-link btn-sm" invisible="1"/>
                                 </tree>


### PR DESCRIPTION
Corrects field references in `maintenance_workorder_mobile_form.xml` to resolve a `ParseError` during module upgrade.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa582070-ef82-4929-ba86-ad572c6e82b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa582070-ef82-4929-ba86-ad572c6e82b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

