### PR TITLE
Fix missing field in mobile work order view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -26,6 +26,7 @@
             <form string="Work Order (Mobile)" class="o_mobile_form">
                 <header>
                     <field name="status" invisible="1"/>
+                    <field name="state" invisible="1"/>
                     <field name="approval_state" invisible="1"/>
                     <field name="work_order_type" invisible="1"/>
                     <field name="schedule_id" invisible="1"/>


### PR DESCRIPTION
Add missing `state` field to `maintenance_workorder_mobile_form.xml` to resolve `ParseError` caused by modifiers referencing an absent field.

---
<a href="https://cursor.com/background-agent?bcId=bc-229021db-9db8-40ba-8c84-c022d31b17aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-229021db-9db8-40ba-8c84-c022d31b17aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

