### PR TITLE
Fix missing field in mobile work order view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -172,10 +172,10 @@
                                     <field name="section_id"/>
                                     <field name="name" readonly="1"/>
                                     <field name="description" readonly="1"/>
-                                    <field name="is_done" widget="boolean_toggle" readonly="state != 'in_progress'"/>
+                                    <field name="is_done" widget="boolean_toggle" readonly="workorder_status != 'in_progress'"/>
                                     <field name="before_image" widget="image" optional="show" string="Before"/>
                                     <field name="after_image" widget="image" optional="show" string="After"/>
-                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="state != 'in_progress'"/>
+                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="workorder_status != 'in_progress'"/>
                                     <button name="action_view_task_mobile" type="object" string="Edit Task" class="btn btn-primary btn-sm"/>
                                     <button name="action_row_click_mobile" type="object" string="Open Task" class="btn btn-link btn-sm" invisible="1"/>
                                 </tree>


### PR DESCRIPTION
Fixes ParseError in mobile work order form by correcting state field reference in task tree view.

The `maintenance_workorder_mobile_form.xml` view was failing to load because modifiers within the `workorder_task_ids` tree view incorrectly referenced `state`. This `state` referred to the task's state, not the parent workorder's state. By changing `state` to `workorder_status` (a field on the task model related to the workorder's state), the view now correctly applies visibility and readonly conditions based on the workorder's status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b64f6744-173e-47e0-8b1c-6663d0ae705f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b64f6744-173e-47e0-8b1c-6663d0ae705f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

