### PR TITLE
Fix missing field in mobile work order view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -9,7 +9,7 @@
                 <field name="name"/>
                 <field name="asset_id"/>
                 <field name="building_id"/>
-                <field name="status" widget="badge" decoration-info="status == 'draft'" decoration-warning="status == 'in_progress'" decoration-success="status == 'completed'" decoration-danger="status == 'cancelled'"/>
+                <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'in_progress'" decoration-success="state == 'completed'" decoration-danger="state == 'cancelled'"/>
                 <field name="priority" widget="badge" decoration-info="priority == '0'" decoration-warning="priority == '3'" decoration-danger="priority == '4'"/>
                 <field name="sla_response_status" widget="badge" decoration-info="sla_response_status == 'on_time'" decoration-warning="sla_response_status == 'at_risk'" decoration-danger="sla_response_status == 'breached'"/>
                 <field name="sla_resolution_status" widget="badge" decoration-info="sla_resolution_status == 'on_time'" decoration-warning="sla_resolution_status == 'at_risk'" decoration-danger="sla_resolution_status == 'breached'"/>
@@ -25,7 +25,6 @@
         <field name="arch" type="xml">
             <form string="Work Order (Mobile)" class="o_mobile_form">
                 <header>
-                    <field name="status" invisible="1"/>
                     <field name="state" invisible="1"/>
                     <field name="approval_state" invisible="1"/>
                     <field name="work_order_type" invisible="1"/>
@@ -40,19 +39,19 @@
 
                     <div class="d-flex flex-wrap gap-2 mb-3">
                         <button name="action_start_progress" type="object" string="Start Work" class="btn btn-primary btn-lg"
-                            invisible="status not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')"
+                            invisible="state not in ('draft', 'assigned') or approval_state not in ('approved', 'draft', 'submitted', 'supervisor', 'manager')"
                             icon="fa-play"/>
                         <button name="action_quick_start" type="object" string="Quick Start" class="btn btn-success btn-lg"
-                            invisible="status != 'draft' or approval_state != 'draft'"
+                            invisible="state != 'draft' or approval_state != 'draft'"
                             icon="fa-bolt"/>
                         <button name="action_resume_work" type="object" string="Resume" class="btn btn-warning btn-lg"
-                            invisible="status != 'on_hold'"
+                            invisible="state != 'on_hold'"
                             icon="fa-refresh"/>
                         <button name="action_complete" type="object" string="Complete" class="btn btn-success btn-lg"
-                            invisible="status != 'in_progress'"
+                            invisible="state != 'in_progress'"
                             icon="fa-check"/>
                         <button name="action_stop_work" type="object" string="Stop Work" class="btn btn-danger btn-lg"
-                            invisible="status != 'in_progress'"
+                            invisible="state != 'in_progress'"
                             icon="fa-stop"/>
                     </div>
                 </header>
@@ -118,11 +117,11 @@
                         <div class="card-body">
                             <group>
                                 <group>
-                                    <field name="actual_start_date" readonly="status in ('completed', 'cancelled')"/>
+                                    <field name="actual_start_date" readonly="state in ('completed', 'cancelled')"/>
                                     <field name="estimated_duration" readonly="1"/>
                                 </group>
                                 <group>
-                                    <field name="actual_end_date" readonly="status in ('draft', 'assigned', 'cancelled')"/>
+                                    <field name="actual_end_date" readonly="state in ('draft', 'assigned', 'cancelled')"/>
                                     <field name="actual_duration" readonly="1"/>
                                 </group>
                             </group>
@@ -136,13 +135,13 @@
                         <div class="card-body">
                             <group>
                                 <group>
-                                    <field name="labor_cost" readonly="status in ('completed', 'cancelled')"/>
+                                    <field name="labor_cost" readonly="state in ('completed', 'cancelled')"/>
                                 </group>
                                 <group>
                                     <field name="parts_cost" readonly="1"/>
                                 </group>
                             </group>
-                            <field name="parts_used_ids" readonly="status != 'in_progress'" nolabel="1">
+                            <field name="parts_used_ids" readonly="state != 'in_progress'" nolabel="1">
                                 <tree editable="bottom">
                                     <field name="product_id"/>
                                     <field name="quantity"/>
@@ -172,10 +171,10 @@
                                     <field name="section_id"/>
                                     <field name="name" readonly="1"/>
                                     <field name="description" readonly="1"/>
-                                                                    <field name="is_done" widget="boolean_toggle" readonly="status != 'in_progress'"/>
+                                                                    <field name="is_done" widget="boolean_toggle" readonly="state != 'in_progress'"/>
                                 <field name="before_image" widget="image" optional="show" string="Before"/>
                                 <field name="after_image" widget="image" optional="show" string="After"/>
-                                <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="status != 'in_progress'"/>
+                                <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="state != 'in_progress'"/>
                                     <button name="action_view_task_mobile" type="object" string="Edit Task" class="btn btn-primary btn-sm"/>
                                     <button name="action_row_click_mobile" type="object" string="Open Task" class="btn btn-link btn-sm" invisible="1"/>
                                 </tree>
@@ -188,13 +187,13 @@
                             <h5 class="mb-0"><i class="fa fa-sticky-note me-2"></i>Work Summary &amp; Notes</h5>
                         </div>
                         <div class="card-body">
-                            <field name="work_done" placeholder="Describe the work performed, issues found, and solutions applied..." readonly="status == 'cancelled'"/>
+                            <field name="work_done" placeholder="Describe the work performed, issues found, and solutions applied..." readonly="state == 'cancelled'"/>
                             <group>
                                 <group>
-                                    <field name="first_time_fix" widget="boolean_toggle" readonly="status in ('draft', 'assigned', 'cancelled')"/>
+                                    <field name="first_time_fix" widget="boolean_toggle" readonly="state in ('draft', 'assigned', 'cancelled')"/>
                                 </group>
                                 <group>
-                                    <field name="service_type" readonly="status in ('completed', 'cancelled')"/>
+                                    <field name="service_type" readonly="state in ('completed', 'cancelled')"/>
                                 </group>
                             </group>
                         </div>


### PR DESCRIPTION
Fixes ParseError in mobile workorder view by replacing `status` field with `state` in modifiers.

The `status` field was a related field to `state` and was marked `invisible="1"` in the view. Odoo's view validation failed because a hidden related field was referenced in modifiers, leading to a `ParseError` during module loading. Using the direct `state` field resolves this validation issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-66bc442f-df87-4223-bcf2-f1f67b139838">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66bc442f-df87-4223-bcf2-f1f67b139838">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

