### PR TITLE
Fix facilities management view error

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -171,10 +171,10 @@
                                     <field name="section_id"/>
                                     <field name="name" readonly="1"/>
                                     <field name="description" readonly="1"/>
-                                                                    <field name="is_done" widget="boolean_toggle" readonly="state != 'in_progress'"/>
-                                <field name="before_image" widget="image" optional="show" string="Before"/>
-                                <field name="after_image" widget="image" optional="show" string="After"/>
-                                <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="state != 'in_progress'"/>
+                                    <field name="is_done" widget="boolean_toggle" readonly="parent.state != 'in_progress'"/>
+                                    <field name="before_image" widget="image" optional="show" string="Before"/>
+                                    <field name="after_image" widget="image" optional="show" string="After"/>
+                                    <button name="toggle_task_completion" type="object" string="Toggle" class="btn btn-secondary btn-sm" invisible="parent.state != 'in_progress'"/>
                                     <button name="action_view_task_mobile" type="object" string="Edit Task" class="btn btn-primary btn-sm"/>
                                     <button name="action_row_click_mobile" type="object" string="Open Task" class="btn btn-link btn-sm" invisible="1"/>
                                 </tree>


### PR DESCRIPTION
Fixes `ParseError` in mobile work order form by correctly referencing parent state in nested tree view modifiers.

The `state` field, belonging to the main `maintenance.workorder` record, was incorrectly referenced directly within the `workorder_task_ids` tree view. This caused a parsing error as `state` was not available in the child task's context. Changing it to `parent.state` ensures the modifiers correctly access the parent workorder's state.

---
<a href="https://cursor.com/background-agent?bcId=bc-00145241-4a32-4c84-900c-ec0bba2395db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00145241-4a32-4c84-900c-ec0bba2395db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

