### PR TITLE
Fix missing field in maintenance task view

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_task_actions.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_task_actions.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <form string="Task (Mobile)" class="o_mobile_form">
                 <header>
-                    <!-- Removed workorder_id field from header -->
+                    <field name="workorder_id" invisible="1"/>
                     <div class="alert alert-info" role="alert" invisible="workorder_id.state == 'in_progress'">
                         <i class="fa fa-info-circle me-2"></i>
                         <strong>Work Order must be "In Progress" to complete tasks and upload images.</strong>


### PR DESCRIPTION
Add `workorder_id` field to mobile form view to resolve `ParseError`.

The `ParseError` occurred because the `workorder_id` field was referenced in an `invisible` modifier (`workorder_id.state == 'in_progress'`) but was not present in the view, causing validation to fail. Adding the field with `invisible="1"` makes it available for the modifier without being visible to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-06f08131-9a82-4d04-bb72-73dc4628f660">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06f08131-9a82-4d04-bb72-73dc4628f660">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

