### PR TITLE
Make work order status fields read only

### DIFF
--- a/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
+++ b/odoo17/addons/facilities_management/views/maintenance_workorder_mobile_form.xml
@@ -49,7 +49,7 @@
                                             <small><i class="fa fa-tasks me-1"></i>Current Status</small>
                                         </div>
                                         <div class="card-body py-2">
-                                            <field name="state" widget="selection" 
+                                            <field name="state" widget="selection" readonly="1"
                                                    decoration-info="state == 'draft'" 
                                                    decoration-warning="state == 'in_progress'" 
                                                    decoration-success="state == 'completed'" 
@@ -66,7 +66,7 @@
                                             <small><i class="fa fa-check-circle me-1"></i>Approval Status</small>
                                         </div>
                                         <div class="card-body py-2">
-                                            <field name="approval_state" widget="selection" 
+                                            <field name="approval_state" widget="selection" readonly="1"
                                                    decoration-info="approval_state == 'draft'" 
                                                    decoration-warning="approval_state in ('submitted', 'supervisor')" 
                                                    decoration-success="approval_state == 'approved'" 
@@ -83,7 +83,7 @@
                                             <small><i class="fa fa-wrench me-1"></i>Work Type</small>
                                         </div>
                                         <div class="card-body py-2">
-                                            <field name="work_order_type" widget="selection" 
+                                            <field name="work_order_type" widget="selection" readonly="1"
                                                    decoration-info="work_order_type == 'preventive'" 
                                                    decoration-warning="work_order_type == 'corrective'" 
                                                    decoration-danger="work_order_type == 'emergency'"


### PR DESCRIPTION
Make work order status, approval state, and work type fields read-only in the mobile form view to ensure data integrity.

These fields are critical for tracking the work order's lifecycle and type. Making them read-only prevents direct manual edits on the mobile form, ensuring that changes to status and approval state occur only via designated workflow actions (e.g., 'Start Work', 'Complete'), thereby maintaining data consistency and process adherence.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1d1fed2-5dc8-4473-87f8-95a8f486d73f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d1d1fed2-5dc8-4473-87f8-95a8f486d73f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

